### PR TITLE
Make devise exclude more specific

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,9 @@ Rails.application.routes.draw do
 
   #devise_for :users
   # Use custom invitations and registrations controllers that subclasses devise's
-  unless defined?(::Rake::SprocketsTask)
+  # Devise will try to connect to the DB at initialization, which we don't want
+  # to happen when precompiling assets in the docker build script.
+  unless Rake.try(:application)&.top_level_tasks&.include? 'assets:precompile'
     devise_for :users, :controllers => {
       :registrations => 'tess_devise/registrations',
       :invitations => 'tess_devise/invitations',


### PR DESCRIPTION
When precompiling the assets no database connection is available, so we can't have devise search for one. There was a check, but that was more or less checking if it was run through rake. Running `rake db:setup` would also trigger it, and cause problems as devise would not be correctly initialized. This fixes that.