### PR TITLE
Small bug fixes

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -109,6 +109,8 @@ class Event < ApplicationRecord
   has_ontology_terms(:scientific_topics, branch: OBO_EDAM.topics)
   has_ontology_terms(:operations, branch: OBO_EDAM.operations)
 
+  has_many :stars,  as: :resource, dependent: :destroy
+
   validates :title, :url, presence: true
   validates :capacity, numericality: { greater_than_or_equal_to: 1 }, allow_blank: true
   validates :cost_value, numericality: { greater_than: 0 }, allow_blank: true

--- a/app/models/material.rb
+++ b/app/models/material.rb
@@ -83,6 +83,8 @@ class Material < ApplicationRecord
   has_ontology_terms(:scientific_topics, branch: OBO_EDAM.topics)
   has_ontology_terms(:operations, branch: OBO_EDAM.operations)
 
+  has_many :stars,  as: :resource, dependent: :destroy
+  
   # Remove trailing and squeezes (:squish option) white spaces inside the string (before_validation):
   # e.g. "James     Bond  " => "James Bond"
   auto_strip_attributes :title, :description, :url, :squish => false

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -329,7 +329,7 @@ class User < ApplicationRecord
   end
 
   def consents_to_processing
-    if processing_consent=="0"
+    if processing_consent!="1"
       errors.add(:base, "You must consent to #{TeSS::Config.site['title_short']} processing your data in order to register")
 
       false

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -327,7 +327,7 @@ class User < ApplicationRecord
   end
 
   def consents_to_processing
-    unless processing_consent
+    if processing_consent=="0"
       errors.add(:base, "You must consent to #{TeSS::Config.site['title_short']} processing your data in order to register")
 
       false

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,6 +66,8 @@ class User < ApplicationRecord
 
   validate :consents_to_processing, on: :create, unless: ->(user) { user.using_omniauth? || User.current_user.try(:is_admin?) }
 
+  validates :processing_consent, :presence => true
+  
   accepts_nested_attributes_for :profile
 
   attr_accessor :publicize_email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -65,8 +65,6 @@ class User < ApplicationRecord
             :uniqueness => true
 
   validate :consents_to_processing, on: :create, unless: ->(user) { user.using_omniauth? || User.current_user.try(:is_admin?) }
-
-  validates :processing_consent, :presence => true
   
   accepts_nested_attributes_for :profile
 

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -54,6 +54,8 @@ class Workflow < ApplicationRecord
 
   has_ontology_terms(:scientific_topics, branch: OBO_EDAM.topics)
 
+  has_many :stars,  as: :resource, dependent: :destroy
+  
   validates :title, presence: true
   validates :difficulty_level, controlled_vocabulary: { dictionary: DifficultyDictionary.instance }
 

--- a/lib/tasks/check_urls.rake
+++ b/lib/tasks/check_urls.rake
@@ -43,21 +43,21 @@ def process_record(record)
     next unless res.url
 
     puts "Checking (ER): #{res.id}, #{res.url}"
-    code = get_bad_response(record.url)
+    code = get_bad_response(res.url)
 
     if code
       puts "#{code}|#{record.id}|#{record.url}|#{res.id}|#{res.url}"
-      if record.link_monitor
-        record.link_monitor.fail!(code)
+      if res.link_monitor
+        res.link_monitor.fail!(code)
       else
-        record.create_link_monitor(url: record.url, code: code)
+        res.create_link_monitor(url: res.url, code: code)
       end
     else
-      if record.link_monitor
-        record.link_monitor.success!
+      if res.link_monitor
+        res.link_monitor.success!
       end
     end
-    record.save!
+    res.save!
   end
 end
 

--- a/test/models/star_test.rb
+++ b/test/models/star_test.rb
@@ -31,4 +31,41 @@ class StarTest < ActiveSupport::TestCase
     refute star.valid?
     assert star.errors[:resource].any?
   end
+  
+  test 'can delete a star with associated material' do 
+    user = users(:regular_user)
+    material = materials(:good_material)
+    Star.create(resource: material, user: user)
+    
+    assert_difference('Star.count', -1) do 
+      assert_difference('Material.count', -1) do 
+          material.destroy 
+      end 
+    end 
+  end
+    
+  test 'can delete a star with associated event' do 
+    user = users(:regular_user)
+    event = events(:one)
+    Star.create(resource: event, user: user)
+    
+    assert_difference('Star.count', -1) do 
+      assert_difference('Event.count', -1) do 
+          event.destroy 
+      end 
+    end 
+  end 
+   
+  test 'can delete a star with associated workflow' do 
+    user = users(:regular_user)
+    wf = workflows(:one)
+    Star.create(resource: wf, user: user)
+    
+    assert_difference('Star.count', -1) do 
+      assert_difference('Workflow.count', -1) do 
+          wf.destroy 
+      end 
+    end 
+  end  
+  
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -56,6 +56,16 @@ class UserTest < ActiveSupport::TestCase
     assert_not user.save, 'Saved user with invalid e-mail address'
   end
 
+  test "should not save user with nil processing consent" do
+    user = User.new(@user_params.merge(processing_consent: nil))
+    assert_not user.save, 'Saved user with nil processing_consent address field'
+  end
+
+  test "should not save user with processing consent equal to 0" do
+    user = User.new(@user_params.merge(processing_consent: '0'))
+    assert_not user.save, 'Saved user with processing_consent address field equal to "0"'
+  end  
+  
   test "should not save with nil password" do
     user = User.new(@user_params.merge(password: nil))
     assert user.password_required?


### PR DESCRIPTION
Three small bugs fixed:

####  External resources check_urls task

External resources in the check_urls task weren't checked.

####  Star(favourite) relation

Starring a material -> deleting that material -> checking starred materials led to an error page.
The relation was not set up properly, stars of a material weren't getting deleted after the material was.
Same thing for events and workflows.

####  Privacy policy checkbox

It was possible to register an account without checking the privacy policy checkbox.