### PR TITLE
Collections curation reminder

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,20 +44,8 @@ GIT
       sunspot (= 2.5.0)
 
 GEM
-  remote: https://rails-assets.org/
-  specs:
-    rails-assets-clipboard (1.5.16)
-    rails-assets-devbridge-autocomplete (1.2.27)
-      rails-assets-jquery (>= 1.7)
-    rails-assets-eonasdan-bootstrap-datetimepicker (4.17.47)
-      rails-assets-jquery (>= 1.8.3)
-      rails-assets-moment (>= 2.10.5)
-    rails-assets-jquery (3.6.0)
-    rails-assets-markdown-it (7.0.1)
-    rails-assets-moment (2.15.2)
-
-GEM
   remote: https://rubygems.org/
+  remote: https://rails-assets.org/
   specs:
     actioncable (6.1.6.1)
       actionpack (= 6.1.6.1)
@@ -452,6 +440,15 @@ GEM
       bundler (>= 1.15.0)
       railties (= 6.1.6.1)
       sprockets-rails (>= 2.0.0)
+    rails-assets-clipboard (1.5.16)
+    rails-assets-devbridge-autocomplete (1.2.27)
+      rails-assets-jquery (>= 1.7)
+    rails-assets-eonasdan-bootstrap-datetimepicker (4.17.47)
+      rails-assets-jquery (>= 1.8.3)
+      rails-assets-moment (>= 2.10.5)
+    rails-assets-jquery (3.6.0)
+    rails-assets-markdown-it (7.0.1)
+    rails-assets-moment (2.15.2)
     rails-controller-testing (1.0.5)
       actionpack (>= 5.0.1.rc1)
       actionview (>= 5.0.1.rc1)

--- a/app/assets/stylesheets/collection.scss
+++ b/app/assets/stylesheets/collection.scss
@@ -1,0 +1,14 @@
+.collection_curation_table {
+  border-spacing: 0;
+
+  td {
+    padding: 1px 5px 1px 0 !important;
+  }
+  label {
+    display: block;
+    margin-bottom: 0;
+    font-weight: normal;
+    height: 36px; /* This is a little hacky, but hard to get the label full-height otherwise */
+    cursor: pointer;
+  }
+}

--- a/app/assets/stylesheets/collection.scss
+++ b/app/assets/stylesheets/collection.scss
@@ -8,7 +8,7 @@
     display: block;
     margin-bottom: 0;
     font-weight: normal;
-    height: 36px; /* This is a little hacky, but hard to get the label full-height otherwise */
+    min-height: 36px; /* This is a little hacky, but hard to get the label full-height otherwise */
     cursor: pointer;
   }
 }

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -138,7 +138,7 @@ class CollectionsController < ApplicationController
       return CollectionMaterial if TeSS::Config.feature['materials']
     end
 
-    raise ActiveRecord::AccessDenied
+    raise Pundit::NotAuthorizedError
   end
 
   # since we have not checked all items we have to do a little work

--- a/app/helpers/collections_helper.rb
+++ b/app/helpers/collections_helper.rb
@@ -9,9 +9,9 @@ module CollectionsHelper
   def item_fields(item_class)
     case item_class.name
     when "Event"
-      %i[title organizer event_types start country city eligibility]
+      %i[title organizer event_types start country city eligibility created_at]
     when "Material"
-      %i[title target_audience status]
+      %i[title target_audience status created_at]
     else
       []
     end

--- a/app/helpers/collections_helper.rb
+++ b/app/helpers/collections_helper.rb
@@ -5,4 +5,15 @@ module CollectionsHelper
     "events, from the full catalogue available within #{TeSS::Config.site['title_short']}, " +
     "to address their specific training needs."
 
+
+  def item_fields(item_class)
+    case item_class.name
+    when "Event"
+      %i[title organizer event_types start country city eligibility]
+    when "Material"
+      %i[title target_audience status]
+    else
+      []
+    end
+  end
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -97,6 +97,8 @@ class Collection < ApplicationRecord
   private
 
   def index_items
+    return unless TeSS::Config.solr_enabled
+
     materials.each(&:solr_index)
     events.each(&:solr_index)
   end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -44,6 +44,7 @@ class Collection < ApplicationRecord
       end
 
       integer :user_id
+      integer :collaborator_ids
       boolean :public
       time :created_at
       time :updated_at

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -17,6 +17,12 @@ class Collection < ApplicationRecord
   # Remove trailing and squeezes (:squish option) white spaces inside the string (before_validation):
   # e.g. "James     Bond  " => "James Bond"
   auto_strip_attributes :title, :description, :image_url, :squish => false
+  after_save do
+    index_items if saved_change_to_title?
+  end
+  after_destroy do
+    index_items
+  end
 
   validates :title, presence: true
 
@@ -43,6 +49,7 @@ class Collection < ApplicationRecord
         [user.username, user.full_name].reject(&:blank?) if user
       end
 
+      integer :collaborator_ids, multiple: true
       integer :user_id
       boolean :public
       time :created_at
@@ -87,5 +94,10 @@ class Collection < ApplicationRecord
     return nil
   end
 
+  private
 
+  def index_items
+    materials.each(&:solr_index)
+    events.each(&:solr_index)
+  end
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -44,7 +44,6 @@ class Collection < ApplicationRecord
       end
 
       integer :user_id
-      integer :collaborator_ids
       boolean :public
       time :created_at
       time :updated_at

--- a/app/models/collection_event.rb
+++ b/app/models/collection_event.rb
@@ -1,5 +1,5 @@
 class CollectionEvent < ApplicationRecord
-  belongs_to :event
+  belongs_to :event, touch: true
   belongs_to :collection
 
   include PublicActivity::Common
@@ -7,6 +7,12 @@ class CollectionEvent < ApplicationRecord
   self.primary_key = 'id'
 
   after_save :log_activity
+  after_create do
+    event.solr_index
+  end
+  after_destroy do
+    event.solr_index
+  end
 
   def log_activity
     self.collection.create_activity(:add_event, owner: User.current_user,

--- a/app/models/collection_event.rb
+++ b/app/models/collection_event.rb
@@ -20,6 +20,6 @@ class CollectionEvent < ApplicationRecord
   private
 
   def solr_index
-    material.solr_index if TeSS::Config.solr_enabled
+    event.solr_index if TeSS::Config.solr_enabled
   end
 end

--- a/app/models/collection_event.rb
+++ b/app/models/collection_event.rb
@@ -7,17 +7,19 @@ class CollectionEvent < ApplicationRecord
   self.primary_key = 'id'
 
   after_save :log_activity
-  after_create do
-    event.solr_index
-  end
-  after_destroy do
-    event.solr_index
-  end
+  after_create :solr_index
+  after_destroy :solr_index
 
   def log_activity
     self.collection.create_activity(:add_event, owner: User.current_user,
                                  parameters: { event_id: self.event_id, event_title: self.event.title })
     self.event.create_activity(:add_to_collection, owner: User.current_user,
                                parameters: { collection_id: self.collection_id, collection_title: self.collection.title })
+  end
+
+  private
+
+  def solr_index
+    material.solr_index if TeSS::Config.solr_enabled
   end
 end

--- a/app/models/collection_material.rb
+++ b/app/models/collection_material.rb
@@ -7,6 +7,12 @@ class CollectionMaterial < ApplicationRecord
   self.primary_key = 'id'
 
   after_save :log_activity
+  after_create do
+    material.solr_index
+  end
+  after_destroy do
+    material.solr_index
+  end
 
   def log_activity
     self.collection.create_activity(:add_material, owner: User.current_user,

--- a/app/models/collection_material.rb
+++ b/app/models/collection_material.rb
@@ -7,17 +7,19 @@ class CollectionMaterial < ApplicationRecord
   self.primary_key = 'id'
 
   after_save :log_activity
-  after_create do
-    material.solr_index
-  end
-  after_destroy do
-    material.solr_index
-  end
+  after_create :solr_index
+  after_destroy :solr_index
 
   def log_activity
     self.collection.create_activity(:add_material, owner: User.current_user,
                                  parameters: { material_id: self.material_id, material_title: self.material.title })
     self.material.create_activity(:add_to_collection, owner: User.current_user,
                                   parameters: { collection_id: self.collection_id, collection_title: self.collection.title })
+  end
+
+  private
+
+  def solr_index
+    material.solr_index if TeSS::Config.solr_enabled
   end
 end

--- a/app/models/concerns/curation_queue.rb
+++ b/app/models/concerns/curation_queue.rb
@@ -30,6 +30,8 @@ module CurationQueue
   end
 
   def from_unverified_or_rejected?
+    return true unless user
+
     user.unverified_or_rejected?
   end
 

--- a/app/models/concerns/curation_queue.rb
+++ b/app/models/concerns/curation_queue.rb
@@ -30,12 +30,12 @@ module CurationQueue
   end
 
   def from_unverified_or_rejected?
-    return true unless user
+    return true unless user # no user set is about the same to me as an unverified user
 
     user.unverified_or_rejected?
   end
 
   def from_shadowbanned?
-    user.shadowbanned?
+    user&.shadowbanned?
   end
 end

--- a/app/models/concerns/with_timezone.rb
+++ b/app/models/concerns/with_timezone.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Check a timezone field against known keys, and have a fuzzy finder for it
+module WithTimezone
+  extend ActiveSupport::Concern
+
+  included do
+    before_validation :check_timezone # set to standard key
+
+    validates :timezone, inclusion: { in: ActiveSupport::TimeZone::MAPPING.keys,
+                                      message: 'not found and cannot be linked to a valid timezone',
+                                      allow_blank: true }
+  end
+
+  private
+
+  def check_timezone
+    begin
+      tz_key = find_timezone_key timezone
+      self.timezone = tz_key unless tz_key.nil? || tz_key == timezone
+    rescue StandardError
+      # ignore error
+    end
+    nil
+  end
+
+  def find_timezone_key(name)
+    return name if name.nil?
+
+    # check name vs ActiveSupport
+    timezones = ActiveSupport::TimeZone::MAPPING
+    return name if timezones.keys.include? name
+    return timezones.key(name) unless timezones.key(name).nil?
+
+    # check for linked zones in TZInfo
+    tzinfo = TZInfo::Timezone.get(name)
+    if tzinfo.nil? && tzinfo.is_a?(TZInfo::LinkedTimezone)
+      # repeat search with canonical timezone identifier
+      return find_timezone_key tzinfo.canonical_zone.identifier
+    end
+
+    # otherwise
+    nil
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -87,6 +87,9 @@ class Event < ApplicationRecord
       # TODO: SOLR has a LatLonType to do geospatial searching. Have a look at that
       #       location :latitutde
       #       location :longitude
+      string :collections, multiple: true do
+        collections.where(public: true).map(&:title)
+      end
     end
     # :nocov:
   end
@@ -187,7 +190,7 @@ class Event < ApplicationRecord
 
   def self.facet_fields
     field_list = %w[ content_provider keywords scientific_topics operations tools fields online event_types
-                     venue city country organizer sponsors target_audience eligibility user ]
+                     venue city country organizer sponsors target_audience eligibility user collections ]
 
     field_list.delete('operations') if TeSS::Config.feature['disabled'].include? 'operations'
     field_list.delete('scientific_topics') if TeSS::Config.feature['disabled'].include? 'topics'
@@ -195,6 +198,7 @@ class Event < ApplicationRecord
     field_list.delete('tools') if TeSS::Config.feature['disabled'].include? 'biotools'
     field_list.delete('fields') if TeSS::Config.feature['disabled'].include? 'ardc_fields_of_research'
     field_list.delete('node') unless TeSS::Config.feature['nodes']
+    field_list.delete('collections') unless TeSS::Config.feature['collections']
 
     field_list
   end

--- a/app/models/material.rb
+++ b/app/models/material.rb
@@ -66,6 +66,9 @@ class Material < ApplicationRecord
         user.username if user
       end
       integer :user_id # Used for shadowbans
+      string :collections, multiple: true do
+        collections.where(public: true).map(&:title)
+      end
     end
     # :nocov:
   end
@@ -113,7 +116,7 @@ class Material < ApplicationRecord
   def self.facet_fields
     field_list = %w(scientific_topics operations tools standard_database_or_policy content_provider keywords
                     difficulty_level fields licence target_audience authors contributors resource_type
-                    related_resources user)
+                    related_resources user collections)
 
     field_list.delete('operations') if TeSS::Config.feature['disabled'].include? 'operations'
     field_list.delete('scientific_topics') if TeSS::Config.feature['disabled'].include? 'topics'
@@ -121,6 +124,7 @@ class Material < ApplicationRecord
     field_list.delete('tools') if TeSS::Config.feature['disabled'].include? 'biotools'
     field_list.delete('fields') if TeSS::Config.feature['disabled'].include? 'ardc_fields_of_research'
     field_list.delete('node') unless TeSS::Config.feature['nodes']
+    field_list.delete('collections') unless TeSS::Config.feature['collections']
 
     field_list
   end

--- a/app/policies/collection_policy.rb
+++ b/app/policies/collection_policy.rb
@@ -8,6 +8,10 @@ class CollectionPolicy < ResourcePolicy
     @record.public? || manage?
   end
 
+  def curate?
+    update?
+  end
+
   class Scope < Scope
     def resolve
       Collection.visible_by(@user)

--- a/app/policies/collection_policy.rb
+++ b/app/policies/collection_policy.rb
@@ -12,6 +12,10 @@ class CollectionPolicy < ResourcePolicy
     update?
   end
 
+  def update_curation?
+    curate?
+  end
+
   class Scope < Scope
     def resolve
       Collection.visible_by(@user)

--- a/app/views/collections/curate.html.erb
+++ b/app/views/collections/curate.html.erb
@@ -1,0 +1,43 @@
+<%- model_class = Collection -%>
+<div class="row wrapper">
+  <div class="col-md-12">
+    <div class="page-header">
+      <%= page_title(t('.title', :default => [:'helpers.titles.curate', 'Curate %{type} in %{model} %{title}'], type: @item_class.table_name, model: model_class.model_name.human.titleize.downcase, title: @collection.title)) %>
+    </div>
+    <%= form_for @collection do |f| %>
+      <%= hidden_field_tag "collection[#{@item_class.table_name.singularize}_ids]", "" %>
+      <table class="table table-striped table-hover collection_curation_table">
+        <thead>
+          <tr>
+            <th></th>
+            <%- item_fields(@item_class).each do |field| -%>
+              <th><%= field.to_s.titleize %></th>
+            <%- end %>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+        <% @items.each do |item| %>
+          <%- input_name = "collection[#{@item_class.table_name.singularize}_ids][]" -%>
+          <%- id = "item_#{item.id}" %>
+          <tr>
+            <td>
+              <%= label_tag id do %>
+                <input id="item_<%= item.id %>" type="checkbox" name="<%= input_name %>" value="<%= item.id %>" selected="<%= @collection.send("#{@item_class.table_name.singularize}_ids").include? item.id %>" />
+              <% end %>
+            </td>
+              <%- item_fields(@item_class).each do |field| -%>
+                <td><label for="<%= id %>"><%= [item.send(field)].flatten.join(', ') %></label></td>
+              <% end %>
+              <td><%= link_to 'link', item %></td>
+          </tr>
+        <% end %>
+        </tbody>
+      </table>
+
+      <div class="form-group actions">
+        <%= f.submit class: 'btn btn-primary' %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/collections/curate.html.erb
+++ b/app/views/collections/curate.html.erb
@@ -4,8 +4,7 @@
     <div class="page-header">
       <%= page_title(t('.title', :default => [:'helpers.titles.curate', 'Curate %{type} in %{model} %{title}'], type: @item_class.table_name, model: model_class.model_name.human.titleize.downcase, title: @collection.title)) %>
     </div>
-    <%= form_for @collection do |f| %>
-      <%= hidden_field_tag "collection[#{@item_class.table_name.singularize}_ids]", "" %>
+    <%= form_with url: request.url, local: true, method: :patch do |f| %>
       <table class="table table-striped table-hover collection_curation_table">
         <thead>
           <tr>
@@ -18,12 +17,12 @@
         </thead>
         <tbody>
         <% @items.each do |item| %>
-          <%- input_name = "collection[#{@item_class.table_name.singularize}_ids][]" -%>
           <%- id = "item_#{item.id}" %>
           <tr>
             <td>
               <%= label_tag id do %>
-                <input id="item_<%= item.id %>" type="checkbox" name="<%= input_name %>" value="<%= item.id %>" selected="<%= @collection.send("#{@item_class.table_name.singularize}_ids").include? item.id %>" />
+                <%= hidden_field_tag "reviewed_item_ids[]", item.id %>
+                <input id="item_<%= item.id %>" type="checkbox" name="item_ids[]" value="<%= item.id %>" selected="<%= @collection.send("#{@item_class.table_name.singularize}_ids").include? item.id %>" />
               <% end %>
             </td>
               <%- item_fields(@item_class).each do |field| -%>

--- a/app/views/collections/curate.html.erb
+++ b/app/views/collections/curate.html.erb
@@ -2,9 +2,9 @@
 <div class="row wrapper">
   <div class="col-md-12">
     <div class="page-header row">
-      <%= page_title(t('.title', :default => [:'helpers.titles.curate', 'Curate %{type} in %{model} %{title}'], type: @item_class.table_name, model: model_class.model_name.human.titleize.downcase, title: @collection.title), class: 'col-md-9') %>
-      <div class="col-md-3" style="margin-top: 25px;">
-        <%= label_tag :since, t('.new_items_since', count: @items.length) %>
+      <%= page_title(t('.title', :default => [:'helpers.titles.curate', 'Curate %{type} in %{model} %{title}'], type: @item_class.table_name, model: model_class.model_name.human.titleize.downcase, title: @collection.title), class: 'col-md-8') %>
+      <div class="col-md-4" style="margin-top: 25px;">
+        <%= label_tag :since, t('.new_items_since', default: ['%{count} new items since'], count: @items.length) %>
         <input id="since" type="date" value="<%= @since.strftime('%Y-%m-%d') %>" pattern="\d{4}-\d{2}-\d{2}" onchange="window.location.search='?since='+this.value;" />
       </div>
     </div>
@@ -14,7 +14,7 @@
           <tr>
             <th></th>
             <%- item_fields(@item_class).each do |field| -%>
-              <th><%= field.to_s.titleize %></th>
+              <th><%= t field %></th>
             <%- end %>
             <th></th>
           </tr>
@@ -32,7 +32,7 @@
               <%- item_fields(@item_class).each do |field| -%>
                 <td><label for="<%= id %>"><%= [item.send(field)].flatten.join(', ') %></label></td>
               <% end %>
-              <td><%= link_to 'link', item %></td>
+              <td><%= link_to t('.link', default: [:'helpers.titles.link']), item %></td>
           </tr>
         <% end %>
         </tbody>

--- a/app/views/collections/curate.html.erb
+++ b/app/views/collections/curate.html.erb
@@ -1,8 +1,12 @@
 <%- model_class = Collection -%>
 <div class="row wrapper">
   <div class="col-md-12">
-    <div class="page-header">
-      <%= page_title(t('.title', :default => [:'helpers.titles.curate', 'Curate %{type} in %{model} %{title}'], type: @item_class.table_name, model: model_class.model_name.human.titleize.downcase, title: @collection.title)) %>
+    <div class="page-header row">
+      <%= page_title(t('.title', :default => [:'helpers.titles.curate', 'Curate %{type} in %{model} %{title}'], type: @item_class.table_name, model: model_class.model_name.human.titleize.downcase, title: @collection.title), class: 'col-md-9') %>
+      <div class="col-md-3" style="margin-top: 25px;">
+        <%= label_tag :since, t('.new_items_since', count: @items.length) %>
+        <input id="since" type="date" value="<%= @since.strftime('%Y-%m-%d') %>" pattern="\d{4}-\d{2}-\d{2}" onchange="window.location.search='?since='+this.value;" />
+      </div>
     </div>
     <%= form_with url: request.url, local: true, method: :patch do |f| %>
       <table class="table table-striped table-hover collection_curation_table">
@@ -22,7 +26,7 @@
             <td>
               <%= label_tag id do %>
                 <%= hidden_field_tag "reviewed_item_ids[]", item.id %>
-                <input id="item_<%= item.id %>" type="checkbox" name="item_ids[]" value="<%= item.id %>" selected="<%= @collection.send("#{@item_class.table_name.singularize}_ids").include? item.id %>" />
+                <input id="item_<%= item.id %>" type="checkbox" name="item_ids[]" value="<%= item.id %>" <%= @collection.send("#{@item_class.table_name.singularize}_ids").include?(item.id) ? 'checked' : '' %> />
               <% end %>
             </td>
               <%- item_fields(@item_class).each do |field| -%>

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -8,6 +8,14 @@
       <div class="content_action">
         <%= link_to t('.back', :default => t("helpers.links.back")),
                     collections_path, :class => 'btn btn-info' %>
+        <% if !current_user.nil? and policy(@collection).curate? and TeSS::Config.feature['events'] %>
+            <%= link_to t('.curate_events', :default => t("helpers.links.events")),
+                        curate_events_collection_path(@collection), :class => 'btn btn-primary' %>
+        <% end %>
+        <% if !current_user.nil? and policy(@collection).curate? and TeSS::Config.feature['materials'] %>
+            <%= link_to t('.curate_materials', :default => t("helpers.links.materials")),
+                        curate_materials_collection_path(@collection), :class => 'btn btn-primary' %>
+        <% end %>
         <% if !current_user.nil? and policy(@collection).update? %>
             <%= link_to t('.edit', :default => t("helpers.links.edit")),
                         edit_collection_path(@collection), :class => 'btn btn-primary' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,11 +91,7 @@ Rails.application.routes.draw do
       # collections.
       member do
         %w[events materials].each do |item|
-          next unless TeSS::Config.feature[item]
-
-          get "curate_#{item}", to: 'collections#curate', defaults: { type: item.classify }
-          post "add_#{item.singularize}", to: 'collections#add_item', defaults: { type: item.classify }
-          post "remove_#{item.singularize}", to: 'collections#remove_item', defaults: { type: item.classify }
+          get "curate_#{item}", to: 'collections#curate', defaults: { type: item.classify } if TeSS::Config.feature[item]
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,7 +91,10 @@ Rails.application.routes.draw do
       # collections.
       member do
         %w[events materials].each do |item|
-          get "curate_#{item}", to: 'collections#curate', defaults: { type: item.classify } if TeSS::Config.feature[item]
+          return unless TeSS::Config.feature[item]
+
+          get "curate_#{item}", to: 'collections#curate', defaults: { type: item.classify }
+          patch "curate_#{item}", to: 'collections#update_curation', defaults: { type: item.classify}
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,11 +85,24 @@ Rails.application.routes.draw do
   end
 
   if TeSS::Config.feature['collections'] == true
-    resources :collections, concerns: [:collaboratable, :activities]
+    resources :collections, concerns: %i[collaboratable activities] do
+      # in the future it could be considered to expand this to multiple collections
+      # at the same view, in a kind of matrix-view, useful for people who manage several
+      # collections.
+      member do
+        %w[events materials].each do |item|
+          next unless TeSS::Config.feature[item]
+
+          get "curate_#{item}", to: 'collections#curate', defaults: { type: item.classify }
+          post "add_#{item.singularize}", to: 'collections#add_item', defaults: { type: item.classify }
+          post "remove_#{item.singularize}", to: 'collections#remove_item', defaults: { type: item.classify }
+        end
+      end
+    end
   end
 
   if TeSS::Config.feature['workflows'] == true
-    resources :workflows, concerns: [:collaboratable, :activities] do
+    resources :workflows, concerns: %i[collaboratable activities] do
       member do
         get 'fork'
         get 'embed'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,8 +27,6 @@ class ActiveSupport::TestCase
   def setup
     redis = Redis.new
     redis.flushdb
-
-    Sunspot.session = Sunspot::Rails::StubSessionProxy.new(original_session)
   end
 
   def teardown

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,6 +27,8 @@ class ActiveSupport::TestCase
   def setup
     redis = Redis.new
     redis.flushdb
+
+    Sunspot.session = Sunspot::Rails::StubSessionProxy.new(original_session)
   end
 
   def teardown


### PR DESCRIPTION
Based on #723, best to review after that one is merged.

I'd like to enable the sending of batched reminders for tasks. Expected use-cases:

- `Collection` maintenance. As new materials and events are added it is important to be notified so you can choose to include these in your collection. Multiple tasks can come from a single `Collection` (new `Events`, new `Materials`)
- Topic Suggestions curation queue. There is no mailer right now, and it would be good te be reminded to keep this up to date (also how to find this in the UI?)
- User Curation queue. Right now these are sent individually, and we could keep that behaviour, or choose to add a digest email also.
- Event Curation. This does not exist yet, but is a feature we'd like to add, perhaps based on the UI for adding events to a collection. Add a `hidden` field to Events, set it to false by default, and send an email if there is something to curate (any new events since the last event with `hidden==true`? It may be better to create an actual queue for this.)

## Development overview
If we expect the model to define a method something like
```ruby
def reminders
  return { "Event": { count: 2 }, ... }
end
```

- For topic suggestions the number of open tasks is clear.
- For event curation this could be based on the 
- For collection maintenance this would be the number of items of each type created since collection `updated_at`. (Note that this is slightly different from the current implementation, which takes the created_at day of the last item included in the collection. I would propose to keep that for the controller, since otherwise updating the collection makes you miss events (or materials, as you do not curate them at the same time). To reconcile the difference between behaviours we could colour the newer items differently in the frontend.)

A new job needs to be created then, running every 15 minutes, which first looks through `Reminders` to find one which should fire now (based on the delay time) and then looks at the model to determine if there is anything to remind about.

## Tasks
- [ ] Create a `Reminder` object which contains information about when to get batched reminders (remindable_{id,type}, user_id, days of the week, timezone, localtime).
- [x] Extract timezone handling from `Event` into separate concern
- [ ] Create UI & controller for setting reminders on collection
- [ ] Create a `ReminderJob` which looks through all outstanding reminders and triggers any which have content, sending an email to the `User`
- [ ] Test this `ReminderJob` (timing, sending an email)

Option: Topic suggestion, Event curation queue

- [ ] Define reminders on a remindable_type only, without ID? So we can add them to Event and EditSuggestion directly?
- [ ] Add UI to set these reminders on your own user account (if you have the right role)