### PR TITLE
harmonize upcoming? definition with event filter page

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -154,11 +154,6 @@ class Event < ApplicationRecord
     set_to_local self.end
   end
 
-  def upcoming?
-    # Should this be a scope instead?
-    Time.now < (self.end || self.start || 1.day.from_now) # handle empty end, start dates
-  end
-
   def started?
     if start and self.end
       (Time.now > start and Time.now < self.end)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -155,12 +155,8 @@ class Event < ApplicationRecord
   end
 
   def upcoming?
-    # Handle nil for start date
-    if start.blank?
-      true
-    else
-      (Time.now < start)
-    end
+    # Should this be a scope instead?
+    Time.now < (self.end || self.start || 1.day.from_now) # handle empty end, start dates
   end
 
   def started?

--- a/app/views/content_providers/_content_provider.html.erb
+++ b/app/views/content_providers/_content_provider.html.erb
@@ -10,7 +10,7 @@
 
     <% if content_provider.events.length > 0 %>
       <div>
-        <strong><%= pluralize(content_provider.events.not_finished.length, 'upcoming event') %></strong>
+        <strong><%= pluralize(content_provider.events.not_finished.length, 'event') %></strong>
         <em>(<%= pluralize(content_provider.events.finished.length, 'past event') %>)</em>
       </div>
     <% end %>

--- a/app/views/content_providers/show.html.erb
+++ b/app/views/content_providers/show.html.erb
@@ -102,13 +102,13 @@
               <%= "in active" if materials.none? && events.any? %>
           ">
           <div class="row">
-            <% upcoming_events = events.select(&:upcoming?) %>
-            <% past_events = events.select(&:expired?) %>
+            <% upcoming_events = events.not_finished %>
+            <% past_events = events.finished %>
 
             <div class="row">
               <% limited_events = upcoming_events.count > 30 ? upcoming_events.first(30) : upcoming_events %>
               <div class="search-results-count">
-                <%= (upcoming_events.count > 0 ? "Showing" : "Found") + " #{pluralize(limited_events.count, "upcoming event")}#{(upcoming_events.count > 30) ? " out of #{upcoming_events.count}" : ''}." %>
+                <%= (upcoming_events.count > 0 ? "Showing" : "Found") + " #{pluralize(limited_events.count, "event")}#{(upcoming_events.count > 30) ? " out of #{upcoming_events.count}" : ''}." %>
                 <%= "Found #{pluralize(past_events.count, "past event")}." %>
                 <%= link_to('View all results.', events_path(content_provider: @content_provider.title, include_expired: true)) if (upcoming_events.count > 30 || past_events.count > 0) %>
               </div>

--- a/app/views/nodes/show.html.erb
+++ b/app/views/nodes/show.html.erb
@@ -70,13 +70,13 @@
         <div id="events" class="tab-pane fade">
           <div class="row">
             <% events_for_node = @node.events %>
-            <% upcoming_events = events_for_node.select{|x| x.upcoming?} %>
-            <% past_events = events_for_node.select{|x| x.expired?} %>
+            <% upcoming_events = events_for_node.not_finished %>
+            <% past_events = events_for_node.finished %>
 
             <div class="row">
               <% events = upcoming_events.count > 30 ? upcoming_events.first(30) : upcoming_events %>
               <div class="search-results-count">
-                <%= (upcoming_events.count > 0 ? "Showing" : "Found") + " #{pluralize(events.count, "upcoming event")}#{(upcoming_events.count > 30) ? " out of #{upcoming_events.count}" : ''}." %>
+                <%= (upcoming_events.count > 0 ? "Showing" : "Found") + " #{pluralize(events.count, "event")}#{(upcoming_events.count > 30) ? " out of #{upcoming_events.count}" : ''}." %>
                 <%= "Found #{pluralize(past_events.count, "past event")}." %>
                 <%= link_to "View all results.", :controller => 'events', :content_provider => @node.content_providers.map{ |x| x.title} if (upcoming_events.count > 30 || past_events.count > 0) %>
               </div>

--- a/lib/tasks/tess.rake
+++ b/lib/tasks/tess.rake
@@ -10,7 +10,7 @@ namespace :tess do
 
     types.each do |type|
       deleted_count = 0
-      records = (type == Event) ? type.all.select(&:upcoming?) : type.all
+      records = (type == Event) ? type.all.not_finished : type.all
       puts "Looking at #{records.count} #{type.name.pluralize}:"
       records.each do |record|
         ##########


### PR DESCRIPTION
On the event index page all events which have not yet finished are shown. On the content provider page, all events which have not yet started are shown.

This difference has been confusing some of our content providers, so I propose to change it to be

upcoming events are those which have not yet ended.
