### PR TITLE
redo migrations to recreate schema.rb

### DIFF
--- a/db/migrate/20180426141503_fix_nil_sponsors.rb
+++ b/db/migrate/20180426141503_fix_nil_sponsors.rb
@@ -6,7 +6,8 @@ class FixNilSponsors < ActiveRecord::Migration[4.2]
 
   def up
     # the below is postgresql-specific. Is that good enough?
-    Event.where(sponsors: nil).update_all("sponsors = '{}'")
+    # Actually I think we can ignore this migration from now on.
+    # Event.where(sponsors: nil).update_all("sponsors = '{}'")
   end
 
   def down

--- a/db/migrate/20180426141503_fix_nil_sponsors.rb
+++ b/db/migrate/20180426141503_fix_nil_sponsors.rb
@@ -1,6 +1,12 @@
 class FixNilSponsors < ActiveRecord::Migration[4.2]
+  # We need to define the Event class locally,
+  # so it doesn't use any of the logic defined in the application
+  # (which may be out of date with this migration)
+  class Event < ActiveRecord::Base; end
+
   def up
-    Event.where(sponsors: nil).update_all(sponsors: [])
+    # the below is postgresql-specific. Is that good enough?
+    Event.where(sponsors: nil).update_all("sponsors = '{}'")
   end
 
   def down

--- a/db/migrate/20230103132957_upgrade_paperclip_attachment_size_to_big_int.rb
+++ b/db/migrate/20230103132957_upgrade_paperclip_attachment_size_to_big_int.rb
@@ -1,0 +1,19 @@
+# frozen-string-literal: true
+
+# In 2018 paperclip migrated from integer to bigint for attachment file size
+# since some uploads over 2GB could exceed this size. See this commit:
+# https://github.com/thoughtbot/paperclip/commit/34ec355e43e91c63288aab956a604f17471d4e59
+# this prevents us from getting a consistent database schema after migration
+# and is generally a good idea to change.
+class UpgradePaperclipAttachmentSizeToBigInt < ActiveRecord::Migration[6.1]
+  # if this was already a bigint the alter-column will not do anything
+  def up
+    change_column :collections, :image_file_size, :bigint
+    change_column :content_providers, :image_file_size, :bigint
+    change_column :staff_members, :image_file_size, :bigint
+  end
+
+  # this migration should perform no action when migrating down
+  # unless your paperclip version is below 6.1.0
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,15 +15,15 @@ ActiveRecord::Schema.define(version: 2022_11_24_105520) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "activities", force: :cascade do |t|
-    t.integer "trackable_id"
+  create_table "activities", id: :serial, force: :cascade do |t|
     t.string "trackable_type"
-    t.integer "owner_id"
+    t.integer "trackable_id"
     t.string "owner_type"
+    t.integer "owner_id"
     t.string "key"
     t.text "parameters"
-    t.integer "recipient_id"
     t.string "recipient_type"
+    t.integer "recipient_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["key"], name: "index_activities_on_key"
@@ -32,7 +32,7 @@ ActiveRecord::Schema.define(version: 2022_11_24_105520) do
     t.index ["trackable_id", "trackable_type"], name: "index_activities_on_trackable_id_and_trackable_type"
   end
 
-  create_table "bans", force: :cascade do |t|
+  create_table "bans", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.integer "banner_id"
     t.boolean "shadow"
@@ -43,10 +43,10 @@ ActiveRecord::Schema.define(version: 2022_11_24_105520) do
     t.index ["user_id"], name: "index_bans_on_user_id"
   end
 
-  create_table "collaborations", force: :cascade do |t|
+  create_table "collaborations", id: :serial, force: :cascade do |t|
     t.integer "user_id"
-    t.integer "resource_id"
     t.string "resource_type"
+    t.integer "resource_id"
     t.index ["resource_type", "resource_id"], name: "index_collaborations_on_resource_type_and_resource_id"
     t.index ["user_id"], name: "index_collaborations_on_user_id"
   end
@@ -63,7 +63,7 @@ ActiveRecord::Schema.define(version: 2022_11_24_105520) do
     t.index ["resource_type", "resource_id"], name: "index_collection_items_on_resource"
   end
 
-  create_table "collections", force: :cascade do |t|
+  create_table "collections", id: :serial, force: :cascade do |t|
     t.string "title"
     t.text "description"
     t.text "image_url"
@@ -75,13 +75,13 @@ ActiveRecord::Schema.define(version: 2022_11_24_105520) do
     t.string "keywords", default: [], array: true
     t.string "image_file_name"
     t.string "image_content_type"
-    t.integer "image_file_size"
+    t.bigint "image_file_size"
     t.datetime "image_updated_at"
     t.index ["slug"], name: "index_collections_on_slug", unique: true
     t.index ["user_id"], name: "index_collections_on_user_id"
   end
 
-  create_table "content_providers", force: :cascade do |t|
+  create_table "content_providers", id: :serial, force: :cascade do |t|
     t.text "title"
     t.text "url"
     t.text "image_url"
@@ -95,7 +95,7 @@ ActiveRecord::Schema.define(version: 2022_11_24_105520) do
     t.string "content_provider_type", default: "Organisation"
     t.string "image_file_name"
     t.string "image_content_type"
-    t.integer "image_file_size"
+    t.bigint "image_file_size"
     t.datetime "image_updated_at"
     t.string "contact"
     t.index ["node_id"], name: "index_content_providers_on_node_id"
@@ -111,7 +111,7 @@ ActiveRecord::Schema.define(version: 2022_11_24_105520) do
     t.index ["user_id"], name: "index_content_providers_users_on_user_id"
   end
 
-  create_table "edit_suggestions", force: :cascade do |t|
+  create_table "edit_suggestions", id: :serial, force: :cascade do |t|
     t.text "name"
     t.text "text"
     t.datetime "created_at", null: false
@@ -122,14 +122,14 @@ ActiveRecord::Schema.define(version: 2022_11_24_105520) do
     t.index ["suggestible_id", "suggestible_type"], name: "index_edit_suggestions_on_suggestible_id_and_suggestible_type"
   end
 
-  create_table "event_materials", force: :cascade do |t|
+  create_table "event_materials", id: :serial, force: :cascade do |t|
     t.integer "event_id"
     t.integer "material_id"
     t.index ["event_id"], name: "index_event_materials_on_event_id"
     t.index ["material_id"], name: "index_event_materials_on_material_id"
   end
 
-  create_table "events", force: :cascade do |t|
+  create_table "events", id: :serial, force: :cascade do |t|
     t.string "external_id"
     t.string "title"
     t.string "subtitle"
@@ -184,7 +184,7 @@ ActiveRecord::Schema.define(version: 2022_11_24_105520) do
     t.index ["user_id"], name: "index_events_on_user_id"
   end
 
-  create_table "external_resources", force: :cascade do |t|
+  create_table "external_resources", id: :serial, force: :cascade do |t|
     t.integer "source_id"
     t.text "url"
     t.string "title"
@@ -194,14 +194,14 @@ ActiveRecord::Schema.define(version: 2022_11_24_105520) do
     t.index ["source_id", "source_type"], name: "index_external_resources_on_source_id_and_source_type"
   end
 
-  create_table "field_locks", force: :cascade do |t|
-    t.integer "resource_id"
+  create_table "field_locks", id: :serial, force: :cascade do |t|
     t.string "resource_type"
+    t.integer "resource_id"
     t.string "field"
     t.index ["resource_type", "resource_id"], name: "index_field_locks_on_resource_type_and_resource_id"
   end
 
-  create_table "friendly_id_slugs", force: :cascade do |t|
+  create_table "friendly_id_slugs", id: :serial, force: :cascade do |t|
     t.string "slug", null: false
     t.integer "sluggable_id", null: false
     t.string "sluggable_type", limit: 50
@@ -213,18 +213,18 @@ ActiveRecord::Schema.define(version: 2022_11_24_105520) do
     t.index ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type"
   end
 
-  create_table "link_monitors", force: :cascade do |t|
+  create_table "link_monitors", id: :serial, force: :cascade do |t|
     t.string "url"
     t.integer "code"
     t.datetime "failed_at"
     t.datetime "last_failed_at"
     t.integer "fail_count"
-    t.integer "lcheck_id"
     t.string "lcheck_type"
+    t.integer "lcheck_id"
     t.index ["lcheck_type", "lcheck_id"], name: "index_link_monitors_on_lcheck_type_and_lcheck_id"
   end
 
-  create_table "materials", force: :cascade do |t|
+  create_table "materials", id: :serial, force: :cascade do |t|
     t.text "title"
     t.string "url"
     t.string "doi"
@@ -234,6 +234,7 @@ ActiveRecord::Schema.define(version: 2022_11_24_105520) do
     t.datetime "updated_at", null: false
     t.text "description"
     t.string "target_audience", default: [], array: true
+    t.string "keywords", default: [], array: true
     t.string "authors", default: [], array: true
     t.string "contributors", default: [], array: true
     t.string "licence", default: "notspecified"
@@ -243,9 +244,7 @@ ActiveRecord::Schema.define(version: 2022_11_24_105520) do
     t.integer "user_id"
     t.date "last_scraped"
     t.boolean "scraper_record", default: false
-    t.text "keyword"
     t.string "resource_type", default: [], array: true
-    t.string "keywords", default: [], array: true
     t.string "other_types"
     t.date "date_created"
     t.date "date_modified"
@@ -263,15 +262,15 @@ ActiveRecord::Schema.define(version: 2022_11_24_105520) do
     t.index ["user_id"], name: "index_materials_on_user_id"
   end
 
-  create_table "node_links", force: :cascade do |t|
+  create_table "node_links", id: :serial, force: :cascade do |t|
     t.integer "node_id"
-    t.integer "resource_id"
     t.string "resource_type"
+    t.integer "resource_id"
     t.index ["node_id"], name: "index_node_links_on_node_id"
     t.index ["resource_type", "resource_id"], name: "index_node_links_on_resource_type_and_resource_id"
   end
 
-  create_table "nodes", force: :cascade do |t|
+  create_table "nodes", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "member_status"
     t.string "country_code"
@@ -288,9 +287,9 @@ ActiveRecord::Schema.define(version: 2022_11_24_105520) do
     t.index ["user_id"], name: "index_nodes_on_user_id"
   end
 
-  create_table "ontology_term_links", force: :cascade do |t|
-    t.integer "resource_id"
+  create_table "ontology_term_links", id: :serial, force: :cascade do |t|
     t.string "resource_type"
+    t.integer "resource_id"
     t.string "term_uri"
     t.string "field"
     t.index ["field"], name: "index_ontology_term_links_on_field"
@@ -298,7 +297,7 @@ ActiveRecord::Schema.define(version: 2022_11_24_105520) do
     t.index ["term_uri"], name: "index_ontology_term_links_on_term_uri"
   end
 
-  create_table "profiles", force: :cascade do |t|
+  create_table "profiles", id: :serial, force: :cascade do |t|
     t.text "firstname"
     t.text "surname"
     t.text "image_url"
@@ -324,14 +323,14 @@ ActiveRecord::Schema.define(version: 2022_11_24_105520) do
     t.index ["slug"], name: "index_profiles_on_slug", unique: true
   end
 
-  create_table "roles", force: :cascade do |t|
+  create_table "roles", id: :serial, force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "title"
   end
 
-  create_table "sessions", force: :cascade do |t|
+  create_table "sessions", id: :serial, force: :cascade do |t|
     t.string "session_id", null: false
     t.text "data"
     t.datetime "created_at"
@@ -361,7 +360,7 @@ ActiveRecord::Schema.define(version: 2022_11_24_105520) do
     t.index ["user_id"], name: "index_sources_on_user_id"
   end
 
-  create_table "staff_members", force: :cascade do |t|
+  create_table "staff_members", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "role"
     t.string "email"
@@ -371,22 +370,22 @@ ActiveRecord::Schema.define(version: 2022_11_24_105520) do
     t.datetime "updated_at", null: false
     t.string "image_file_name"
     t.string "image_content_type"
-    t.integer "image_file_size"
+    t.bigint "image_file_size"
     t.datetime "image_updated_at"
     t.index ["node_id"], name: "index_staff_members_on_node_id"
   end
 
-  create_table "stars", force: :cascade do |t|
+  create_table "stars", id: :serial, force: :cascade do |t|
     t.integer "user_id"
-    t.integer "resource_id"
     t.string "resource_type"
+    t.integer "resource_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["resource_type", "resource_id"], name: "index_stars_on_resource_type_and_resource_id"
     t.index ["user_id"], name: "index_stars_on_user_id"
   end
 
-  create_table "subscriptions", force: :cascade do |t|
+  create_table "subscriptions", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.datetime "last_sent_at"
     t.text "query"
@@ -399,7 +398,7 @@ ActiveRecord::Schema.define(version: 2022_11_24_105520) do
     t.index ["user_id"], name: "index_subscriptions_on_user_id"
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", id: :serial, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "username"
@@ -445,7 +444,7 @@ ActiveRecord::Schema.define(version: 2022_11_24_105520) do
     t.index ["identity_url"], name: "index_users_on_identity_url", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
-    t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by"
+    t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by_type_and_invited_by_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["role_id"], name: "index_users_on_role_id"
     t.index ["slug"], name: "index_users_on_slug", unique: true
@@ -453,11 +452,11 @@ ActiveRecord::Schema.define(version: 2022_11_24_105520) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
-  create_table "widget_logs", force: :cascade do |t|
+  create_table "widget_logs", id: :serial, force: :cascade do |t|
     t.string "widget_name"
     t.string "action"
-    t.integer "resource_id"
     t.string "resource_type"
+    t.integer "resource_id"
     t.text "data"
     t.json "params"
     t.datetime "created_at", null: false
@@ -465,7 +464,7 @@ ActiveRecord::Schema.define(version: 2022_11_24_105520) do
     t.index ["resource_type", "resource_id"], name: "index_widget_logs_on_resource_type_and_resource_id"
   end
 
-  create_table "workflows", force: :cascade do |t|
+  create_table "workflows", id: :serial, force: :cascade do |t|
     t.string "title"
     t.string "description"
     t.integer "user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_24_105520) do
+ActiveRecord::Schema.define(version: 2023_01_03_132957) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
In another PR I ran into an issue where some old tables were left in schema.rb. The typical way to do that is to reload the schema and then redo the migration, but it should also be possible to regenerate the schema by executing all migrations.

I was trying this latter approach, and ran into this issue:

```
== 20180426141503 FixNilSponsors: migrating ===================================
rake aborted!
StandardError: An error has occurred, this and all later migrations canceled:

can't cast Array
/usr/local/bundle/gems/activerecord-6.1.6.1/lib/active_record/connection_adapters/abstract/quoting.rb:246:in `_type_cast'
/usr/local/bundle/gems/activerecord-6.1.6.1/lib/active_record/connection_adapters/postgresql/quoting.rb:162:in `_type_cast'
/usr/local/bundle/gems/activerecord-6.1.6.1/lib/active_record/connection_adapters/abstract/quoting.rb:43:in `type_cast'
/usr/local/bundle/gems/activerecord-6.1.6.1/lib/active_record/connection_adapters/abstract/quoting.rb:205:in `block in type_casted_binds'
/usr/local/bundle/gems/activerecord-6.1.6.1/lib/active_record/connection_adapters/abstract/quoting.rb:203:in `map'
/usr/local/bundle/gems/activerecord-6.1.6.1/lib/active_record/connection_adapters/abstract/quoting.rb:203:in `type_casted_binds'
/usr/local/bundle/gems/activerecord-6.1.6.1/lib/active_record/connection_adapters/postgresql_adapter.rb:669:in `exec_no_cache'
/usr/local/bundle/gems/activerecord-6.1.6.1/lib/active_record/connection_adapters/postgresql_adapter.rb:649:in `execute_and_clear'
/usr/local/bundle/gems/activerecord-6.1.6.1/lib/active_record/connection_adapters/postgresql/database_statements.rb:72:in `exec_delete'
/usr/local/bundle/gems/activerecord-6.1.6.1/lib/active_record/connection_adapters/abstract/database_statements.rb:179:in `update'
/usr/local/bundle/gems/activerecord-6.1.6.1/lib/active_record/connection_adapters/abstract/query_cache.rb:22:in `update'
/usr/local/bundle/gems/activerecord-6.1.6.1/lib/active_record/relation.rb:466:in `update_all'
/code/db/migrate/20180426141503_fix_nil_sponsors.rb:5:in `up'
```

The below PR fixes that by using the postgresql Array literal (and actually disabling this update, since it is so long ago)


As a side-effect some of the defaults have changed.