### PR TITLE
include events without date in not_finished

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -264,7 +264,7 @@ class Event < ApplicationRecord
   end
 
   def self.not_finished
-    where('events.end > ?', Time.now).where.not(end: nil)
+    where('events.end > ? OR events.end IS NULL', Time.now)
   end
 
   def self.finished

--- a/test/controllers/content_providers_controller_test.rb
+++ b/test/controllers/content_providers_controller_test.rb
@@ -440,24 +440,50 @@ class ContentProvidersControllerTest < ActionController::TestCase
   end
 
   # TODO: SOLR tests will not run on TRAVIS. Explore stratergy for testing solr
-=begin
-      test 'should display filters on index' do
-        get :index
-        assert_select 'h4.nav-heading', :text => /Content provider/, :count => 0
-        assert_select 'div.list-group-item', :count => ContentProvider.count
-      end
-      test 'should return matching content_providers' do
-        get 'index', :format => :json, :q => 'training'
-        assert_response :success
-        assert response.body.size > 0
-      end
+  #       test 'should display filters on index' do
+  #         get :index
+  #         assert_select 'h4.nav-heading', :text => /Content provider/, :count => 0
+  #         assert_select 'div.list-group-item', :count => ContentProvider.count
+  #       end
+  #       test 'should return matching content_providers' do
+  #         get 'index', :format => :json, :q => 'training'
+  #         assert_response :success
+  #         assert response.body.size > 0
+  #       end
+  #
+  #       test 'should return no matching content_providers' do
+  #         get 'index', :format => :json, :q => 'kdfsajfklasdjfljsdfljdsfjncvmn'
+  #         assert_response :success
+  #         assert_equal(response.body,'[]')
+  #         end
 
-      test 'should return no matching content_providers' do
-        get 'index', :format => :json, :q => 'kdfsajfklasdjfljsdfljdsfjncvmn'
-        assert_response :success
-        assert_equal(response.body,'[]')
-        end
-=end
+  # Event count on content provider page
+  test 'show consistent count on content provider page' do
+    sign_in users(:admin)
 
+    @content_provider.events.delete_all
+    # make sure this content provider has events in the past, future and without date
+    good_user = users(:admin)
+    past_event = good_user.events.build(title: 'past',
+                                        url: 'http://example.com/good-stuff',
+                                        end: 3.days.ago,
+                                        content_provider: @content_provider)
+    past_event.save!
+
+    future_event = good_user.events.build(title: 'future',
+                                          url: 'http://example.com/good-stuff',
+                                          end: 4.days.from_now,
+                                          content_provider: @content_provider)
+    future_event.save!
+
+    dateless_event = good_user.events.build(title: 'dateless',
+                                            url: 'http://example.com/good-stuff',
+                                            content_provider: @content_provider)
+    dateless_event.save!
+
+    get :show, params: { id: @content_provider }
+    assert_select 'a[href=?]', '#events', text: 'Events (3)'
+    # this is a bit fragile. may be nicer to use a regex if it breaks
+    assert_select 'div#events div.search-results-count', text: "Showing 2 events.\n                Found 1 past event.\n                View all results."
+  end
 end
-


### PR DESCRIPTION
This causes the event totals on the content provider page to match up with the shown and hidden count.
If you wish not to have this, perhaps we could explicitly include them in the view then, instead of in this scope, or update the text on the view to explain why events without date are also hidden.

example:
![image](https://user-images.githubusercontent.com/35944/200192245-7bbf962d-59fd-4000-a603-9b57f3e159d1.png)