### PR TITLE
Fix popovers not closing properly. Fixes #765

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -186,7 +186,25 @@ document.addEventListener("turbolinks:load", function() {
         }
     });
 
-    $("a[rel~=popover], .has-popover").popover();
+    $('.has-popover').each(function () {
+        $(this).popover({
+            trigger: 'manual'
+        }).click(function (e) {
+            $(this).popover('toggle');
+            e.stopPropagation(); // Stops popover immediately closing from document click handler below.
+        }).on('inserted.bs.popover', function () {
+            $('.popover').click(function (e) {
+                // Prevent clicking the popover content from closing it.
+                // Skips the click event on the document, defined below.
+                e.stopPropagation();
+            })
+        })
+    });
+
+    $(document).click(function () {
+        $('.has-popover').popover('hide');
+    });
+
     $("a[rel~=tooltip], .has-tooltip").tooltip();
 
     // Prevent form being un-intentionally submitted when enter key is pressed in a text field.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -269,7 +269,7 @@ module ApplicationHelper
     classes = 'btn btn-default has-popover'
     classes << " #{opts[:class]}" if opts[:class]
     content_tag(:a, tabindex: 0, class: classes,
-               data: { toggle: 'popover', placement: 'bottom', trigger: 'focus click',
+               data: { toggle: 'popover', placement: 'bottom',
                        title: title, html: true, content: capture(&block) }) do
       "<i class='fa fa-info-circle'></i> <span class='hidden-xs'>#{title}</span>".html_safe
     end


### PR DESCRIPTION
Use some manual JS to handle the opening/closing so that:
- The popover appears when the button is clicked.
- It does not disappear if its contents is clicked.
- It does disappear if any anywhere else is clicked.

Confirmed with @anenadic that it works on Safari 15.1 (MacOS 12.0.1)