### PR TITLE
Collection link in digest mail

### DIFF
--- a/app/mailers/subscription_mailer.rb
+++ b/app/mailers/subscription_mailer.rb
@@ -8,6 +8,7 @@ class SubscriptionMailer < ApplicationMailer
     @user = sub.user
     @digest = dig
     @subscription = sub
+    @collections = Collection.left_outer_joins(:collaborators).where(collaborators: { id: @user.id}).or(Collection.where(user_id: @user.id)).distinct
     subs = pluralize(@digest.total_count, "new #{@subscription.subscribable_type.downcase}")
     subject = "#{TeSS::Config.site['title_short']} #{sub.frequency} digest - #{subs} matching your criteria"
     mail(subject: subject, to: sub.user.email) do |format|

--- a/app/mailers/subscription_mailer.rb
+++ b/app/mailers/subscription_mailer.rb
@@ -8,7 +8,11 @@ class SubscriptionMailer < ApplicationMailer
     @user = sub.user
     @digest = dig
     @subscription = sub
-    @collections = Collection.left_outer_joins(:collaborators).where(collaborators: { id: @user.id}).or(Collection.where(user_id: @user.id)).distinct
+    @collections = if TeSS::Config.feature['collections']
+                     @user.maintained_collections
+                   else
+                     []
+                   end
     subs = pluralize(@digest.total_count, "new #{@subscription.subscribable_type.downcase}")
     subject = "#{TeSS::Config.site['title_short']} #{sub.frequency} digest - #{subs} matching your criteria"
     mail(subject: subject, to: sub.user.email) do |format|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -124,6 +124,10 @@ class User < ApplicationRecord
     self.has_role?('curator')
   end
 
+  def maintained_collections
+    Collection.left_outer_joins(:collaborators).where(collaborators: { id: id }).or(Collection.where(user_id: id)).distinct
+  end
+
   def skip_email_confirmation_for_non_production
     # In development and test environments, set the user as confirmed
     # after creation but before save

--- a/app/views/subscription_mailer/digest.html.erb
+++ b/app/views/subscription_mailer/digest.html.erb
@@ -36,6 +36,19 @@ Dear <%= @user.profile.firstname || @user.username %>,<br/>
   <%= link_to("View all results on #{TeSS::Config.site['title_short']}", subscription_results_url(@subscription)) %>
 </p>
 
+<% if @collections&.any? %>
+<p>
+  Collections you might like to update:
+</p>
+<ul>
+  <% @collections.each do |collection| %>
+    <li>
+      <%= link_to collection.title, send("curate_#{@subscription.subscribable_type.downcase.pluralize}_collection_url", collection) %>
+    </li>
+  <% end -%>
+</ul>
+<% end %>
+
 <hr/>
 
 <small>

--- a/app/views/subscription_mailer/digest.text.erb
+++ b/app/views/subscription_mailer/digest.text.erb
@@ -22,6 +22,14 @@ There <%= @digest.total_count == 1 ? 'has' : 'have' -%> been <%= pluralize(@dige
 View all results on <%= TeSS::Config.site['title_short'] %>:
 <%= subscription_results_url(@subscription) %>
 
+
+<% if @collections&.any? %>
+Collections you might like to update:
+<% @collections.each do |collection| %>
+  <%= collection.title %>: <%= send("curate_#{@subscription.subscribable_type.downcase.pluralize}_collection_url", collection) %>
+<% end %>
+<% end %>
+
 ---------------------------------------------------------
 
 To cancel this subscription, visit the following link:


### PR DESCRIPTION
**Summary of changes**

- Add a list of links to owned & collaborated collections to the digest emails (text & html)

Fixes #790 

Builds on the collections-ui branch, so merge that one before reviewing this.

**Motivation and context**

Make it a trigger point for keeping your curated collection up to date

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
