### PR TITLE
Ensure devise's mailer sets configured headers

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -132,11 +132,11 @@ class User < ApplicationRecord
     # In development and test environments, set the user as confirmed
     # after creation but before save
     # so no confirmation emails are sent
-    self.skip_confirmation! unless Rails.env.production?
+    self.skip_confirmation! unless Rails.env.production? || TeSS::Config.force_user_confirmation
   end
 
   def skip_email_reconfirmation_for_non_production
-    unless Rails.env.production?
+    unless Rails.env.production? || TeSS::Config.force_user_confirmation
       self.unconfirmed_email = nil
       self.skip_reconfirmation!
     end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,10 +12,11 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = TeSS::Config.sender_email
+  # config.mailer_sender = TeSS::Config.sender_email
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
+  config.parent_mailer = 'ApplicationMailer'
 
   # ==> ORM configuration
   # Load and configure the ORM. Supports :active_record (default) and

--- a/test/integration/devise_mailer_test.rb
+++ b/test/integration/devise_mailer_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class DeviseMailerTest < ActionDispatch::IntegrationTest
+  setup do
+    @routes = Rails.application.routes.url_helpers
+    @url_opts = Rails.application.routes.default_url_options
+    Rails.application.routes.default_url_options = Rails.application.config.action_mailer.default_url_options
+    # Avoids queued emails affecting `assert_email` counts. See: https://github.com/ElixirTeSS/TeSS/issues/719
+    perform_enqueued_jobs
+    ActionMailer::Base.deliveries.clear
+  end
+
+  teardown do
+    Rails.application.routes.default_url_options = @url_opts
+  end
+
+  test 'mailer headers are applied to emails from devise' do
+    mailer_settings = TeSS::Config.mailer
+    TeSS::Config.mailer['headers'] = { 'Sender' => 'mail.sender@example.com', 'X-Something' => 'yes' }
+
+    assert_emails 1 do
+      with_settings(force_user_confirmation: true) do
+        post users_path, params: {
+          user: {
+            username: 'mileyfan1997',
+            email: 'h4nn4hm0nt4n4@example.com',
+            password: '12345678',
+            password_confirmation: '12345678',
+            processing_consent: '1'
+          }
+        }
+      end
+    end
+
+    email = ActionMailer::Base.deliveries.last
+    email_headers = {}
+    email.header.fields.each { |f| email_headers[f.name] = f.value }
+
+    assert_equal 'no-reply@example.com', email_headers['From']
+    assert_equal 'mail.sender@example.com', email_headers['Sender']
+    assert_equal 'yes', email_headers['X-Something']
+  ensure
+    TeSS::Config.mailer = mailer_settings
+  end
+end


### PR DESCRIPTION
**Summary of changes**

- Changes Devise's config to inherit its' mailer class from `ApplicationMailer`.
- This ensures custom headers etc. are set.

**Motivation and context**

Confirmation emails etc. were not having these headers applied and so were bouncing.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
