### PR TITLE
Use `with_settings` consistently

### DIFF
--- a/test/controllers/content_providers_controller_test.rb
+++ b/test/controllers/content_providers_controller_test.rb
@@ -27,17 +27,12 @@ class ContentProvidersControllerTest < ActionController::TestCase
   end
 
   test 'should get index with solr enabled' do
-    begin
-      TeSS::Config.solr_enabled = true
-
+    with_settings(solr_enabled: true) do
       ContentProvider.stub(:search_and_filter, MockSearch.new(ContentProvider.all)) do
         get :index, params: { q: 'gossip', keywords: 'celebs' }
         assert_response :success
         assert_not_empty assigns(:content_providers)
       end
-
-    ensure
-      TeSS::Config.solr_enabled = false
     end
   end
 
@@ -65,13 +60,11 @@ class ContentProvidersControllerTest < ActionController::TestCase
   end
 
   test 'should not get index if feature disabled' do
-    features = TeSS::Config.feature.dup
-    TeSS::Config.feature['providers'] = false
-    assert_raises(ActionController::RoutingError) do
-      get :index
+    with_settings(feature: { providers: false }) do
+      assert_raises(ActionController::RoutingError) do
+        get :index
+      end
     end
-  ensure
-    TeSS::Config.feature = features
   end
 
   #NEW TESTS

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -35,16 +35,12 @@ class EventsControllerTest < ActionController::TestCase
   end
 
   test 'should get index with solr enabled' do
-    begin
-      TeSS::Config.solr_enabled = true
-
+    with_settings(solr_enabled: true) do
       Event.stub(:search_and_filter, MockSearch.new(Event.all)) do
         get :index, params: { q: 'nightclub', keywords: 'ragtime' }
         assert_response :success
         assert_not_empty assigns(:events)
       end
-    ensure
-      TeSS::Config.solr_enabled = false
     end
   end
 
@@ -868,9 +864,7 @@ class EventsControllerTest < ActionController::TestCase
   end
 
   test 'should count index results' do
-    begin
-      TeSS::Config.solr_enabled = true
-
+    with_settings(solr_enabled: true) do
       events = Event.all
 
       Event.stub(:search_and_filter, MockSearch.new(events)) do
@@ -881,15 +875,11 @@ class EventsControllerTest < ActionController::TestCase
         assert_equal events.count, output['count']
         assert_equal events_url, output['url']
       end
-    ensure
-      TeSS::Config.solr_enabled = false
     end
   end
 
   test 'should count filtered results' do
-    begin
-      TeSS::Config.solr_enabled = true
-
+    with_settings(solr_enabled: true) do
       events = Event.limit(3)
 
       Event.stub(:search_and_filter, MockSearch.new(events)) do
@@ -901,8 +891,6 @@ class EventsControllerTest < ActionController::TestCase
         assert_equal events_url(q: 'test', keywords: 'dolphins'), output['url']
         assert_equal 'dolphins', output['params']['keywords']
       end
-    ensure
-      TeSS::Config.solr_enabled = false
     end
   end
 
@@ -1258,15 +1246,11 @@ class EventsControllerTest < ActionController::TestCase
   end
 
   test 'should not show identifiers dot org button if disabled' do
-    begin
-      prefix = TeSS::Config.identifiers_prefix
-      TeSS::Config.identifiers_prefix = nil
+    with_settings(identifiers_prefix: nil) do
       get :show, params: { id: @event }
 
       assert_response :success
       assert_select '.identifiers-button', count: 0
-    ensure
-      TeSS::Config.identifiers_prefix = prefix
     end
   end
 
@@ -1304,23 +1288,18 @@ class EventsControllerTest < ActionController::TestCase
   end
 
   test 'should hide map tab if disabled' do
-    disabled = TeSS::Config.feature['disabled'].dup
-
     get :index
     assert_response :success
     assert_select '#content .nav-tabs' do
       assert_select 'li a[href=?]', '#map', count: 1
     end
 
-    TeSS::Config.feature['disabled'] |= ['events_map']
-
-    get :index
-    assert_response :success
-    assert_select '#content .nav-tabs' do
-      assert_select 'li a[href=?]', '#map', count: 0
+    with_settings(feature: { disabled: ['events_map'] }) do
+      get :index
+      assert_response :success
+      assert_select '#content .nav-tabs' do
+        assert_select 'li a[href=?]', '#map', count: 0
+      end
     end
-
-  ensure
-    TeSS::Config.feature['disabled'] = disabled
   end
 end

--- a/test/controllers/materials_controller_test.rb
+++ b/test/controllers/materials_controller_test.rb
@@ -41,17 +41,12 @@ class MaterialsControllerTest < ActionController::TestCase
   end
 
   test 'should get index with solr enabled' do
-    begin
-      TeSS::Config.solr_enabled = true
-
+    with_settings(solr_enabled: true) do
       Material.stub(:search_and_filter, MockSearch.new(Material.all)) do
         get :index, params: { q: 'breakdance for beginners', keywords: 'dancing' }
         assert_response :success
         assert_not_empty assigns(:materials)
       end
-
-    ensure
-      TeSS::Config.solr_enabled = false
     end
   end
 
@@ -91,9 +86,7 @@ class MaterialsControllerTest < ActionController::TestCase
     @material.scientific_topic_uris = ['http://edamontology.org/topic_0654']
     @material.save!
 
-    begin
-      TeSS::Config.solr_enabled = true
-
+    with_settings(solr_enabled: true) do
       Material.stub(:search_and_filter, MockSearch.new(Material.all)) do
         get :index, params: { q: 'breakdance for beginners', keywords: 'dancing', format: :json_api }
         assert_response :success
@@ -112,8 +105,6 @@ class MaterialsControllerTest < ActionController::TestCase
         assert body['links']['self'].include?('dancing')
         assert body['links']['self'].include?('breakdance+for+beginners')
       end
-    ensure
-      TeSS::Config.solr_enabled = false
     end
   end
 
@@ -1081,9 +1072,7 @@ class MaterialsControllerTest < ActionController::TestCase
   end
 
   test 'should count index results' do
-    begin
-      TeSS::Config.solr_enabled = true
-
+    with_settings(solr_enabled: true) do
       materials = Material.all
 
       Material.stub(:search_and_filter, MockSearch.new(materials)) do
@@ -1094,15 +1083,11 @@ class MaterialsControllerTest < ActionController::TestCase
         assert_equal materials.count, output['count']
         assert_equal materials_url, output['url']
       end
-    ensure
-      TeSS::Config.solr_enabled = false
     end
   end
 
   test 'should count filtered results' do
-    begin
-      TeSS::Config.solr_enabled = true
-
+    with_settings(solr_enabled: true) do
       materials = Material.limit(3)
 
       Material.stub(:search_and_filter, MockSearch.new(materials)) do
@@ -1114,8 +1099,6 @@ class MaterialsControllerTest < ActionController::TestCase
         assert_equal materials_url(q: 'test', keywords: 'dolphins'), output['url']
         assert_equal 'dolphins', output['params']['keywords']
       end
-    ensure
-      TeSS::Config.solr_enabled = false
     end
   end
 

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -9,9 +9,7 @@ class SearchControllerTest < ActionController::TestCase
   end
 
   test 'should get index' do
-    begin
-      TeSS::Config.solr_enabled = true
-
+    with_settings(solr_enabled: true) do
       search_method = proc { |model| MockSearch.new(model.limit(3).to_a) }
 
       Sunspot.blockless_stub(:search, search_method) do
@@ -19,9 +17,6 @@ class SearchControllerTest < ActionController::TestCase
         assert_response :success
         assert_not_empty assigns(:results)
       end
-
-    ensure
-      TeSS::Config.solr_enabled = false
     end
   end
 

--- a/test/controllers/sources_controller_test.rb
+++ b/test/controllers/sources_controller_test.rb
@@ -47,8 +47,7 @@ class SourcesControllerTest < ActionController::TestCase
   end
 
   test 'admin should get index with solr enabled' do
-    begin
-      TeSS::Config.solr_enabled = true
+    with_settings(solr_enabled: true) do
       method = 'event_csv'
       mock_search = MockSearch.new(Source.where(method: method))
       sign_in users(:admin)
@@ -58,8 +57,6 @@ class SourcesControllerTest < ActionController::TestCase
         assert_not_empty assigns(:sources)
         assert_equal 2, assigns(:sources).size, 'provider'
       end
-    ensure
-      TeSS::Config.solr_enabled = false
     end
   end
 

--- a/test/controllers/static_controller_test.rb
+++ b/test/controllers/static_controller_test.rb
@@ -10,18 +10,18 @@ class StaticControllerTest < ActionController::TestCase
   end
 
   test 'should show tabs for enabled features' do
-    features = TeSS::Config.feature.dup
+    features = { 'events': true,
+                 'materials': true,
+                 'e-learnings': true,
+                 'workflows': true,
+                 'collections': true,
+                 'providers': true,
+                 'trainers': true,
+                 'nodes': true }
 
-    TeSS::Config.feature['events'] = true
-    TeSS::Config.feature['materials'] = true
-    TeSS::Config.feature['e-learnings'] = true
-    TeSS::Config.feature['workflows'] = true
-    TeSS::Config.feature['collections'] = true
-    TeSS::Config.feature['providers'] = true
-    TeSS::Config.feature['trainers'] = true
-    TeSS::Config.feature['nodes'] = true
-
-    get :home
+    with_settings(feature: features) do
+      get :home
+    end
 
     assert_select 'ul.nav.navbar-nav' do
       assert_select 'li a[href=?]', workflows_path
@@ -34,23 +34,21 @@ class StaticControllerTest < ActionController::TestCase
       assert_select 'li a[href=?]', trainers_path
       assert_select 'li a[href=?]', nodes_path
     end
-  ensure
-    TeSS::Config.feature = features
   end
 
   test 'should not show tabs for disabled features' do
-    features = TeSS::Config.feature.dup
+    features = { 'events': false,
+                 'materials': false,
+                 'e-learnings': false,
+                 'workflows': false,
+                 'collections': false,
+                 'providers': false,
+                 'trainers': false,
+                 'nodes': false }
 
-    TeSS::Config.feature['events'] = false
-    TeSS::Config.feature['materials'] = false
-    TeSS::Config.feature['e-learnings'] = false
-    TeSS::Config.feature['workflows'] = false
-    TeSS::Config.feature['collections'] = false
-    TeSS::Config.feature['providers'] = false
-    TeSS::Config.feature['trainers'] = false
-    TeSS::Config.feature['nodes'] = false
-
-    get :home
+    with_settings(feature: features) do
+      get :home
+    end
 
     assert_select 'ul.nav.navbar-nav' do
       assert_select 'li a[href=?]', workflows_path, count: 0
@@ -63,7 +61,5 @@ class StaticControllerTest < ActionController::TestCase
       assert_select 'li a[href=?]', trainers_path, count: 0
       assert_select 'li a[href=?]', nodes_path, count: 0
     end
-  ensure
-    TeSS::Config.feature = features
   end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -412,27 +412,23 @@ class UsersControllerTest < ActionController::TestCase
   end
 
   test 'should get invitees if feature enabled' do
-    features = TeSS::Config.feature.dup
-    TeSS::Config.feature['invitation'] = true
-    sign_in @admin
+    with_settings(feature: { invitation: true }) do
+      sign_in @admin
 
-    get :invitees
+      get :invitees
 
-    assert_response :success
-  ensure
-    TeSS::Config.feature = features
+      assert_response :success
+    end
   end
 
   test 'should not get invitees if feature disabled' do
-    features = TeSS::Config.feature.dup
-    TeSS::Config.feature['invitation'] = false
-    sign_in @admin
+    with_settings(feature: { invitation: false }) do
+      sign_in @admin
 
-    assert_raises(ActionController::RoutingError) do
-      get :invitees
+      assert_raises(ActionController::RoutingError) do
+        get :invitees
+      end
     end
-  ensure
-    TeSS::Config.feature = features
   end
 
   test 'should show tabs for resource types and link to view all' do

--- a/test/controllers/workflows_controller_test.rb
+++ b/test/controllers/workflows_controller_test.rb
@@ -14,16 +14,12 @@ class WorkflowsControllerTest < ActionController::TestCase
   end
 
   test 'should get index with solr enabled' do
-    begin
-      TeSS::Config.solr_enabled = true
-
+    with_settings(solr_enabled: true) do
       Workflow.stub(:search_and_filter, MockSearch.new(Workflow.all)) do
         get :index, params: { q: 'bananas', keywords: 'fruit' }
         assert_response :success
         assert_not_empty assigns(:workflows)
       end
-    ensure
-      TeSS::Config.solr_enabled = false
     end
   end
 

--- a/test/integration/devise_mailer_test.rb
+++ b/test/integration/devise_mailer_test.rb
@@ -15,11 +15,9 @@ class DeviseMailerTest < ActionDispatch::IntegrationTest
   end
 
   test 'mailer headers are applied to emails from devise' do
-    mailer_settings = TeSS::Config.mailer
-    TeSS::Config.mailer['headers'] = { 'Sender' => 'mail.sender@example.com', 'X-Something' => 'yes' }
-
     assert_emails 1 do
-      with_settings(force_user_confirmation: true) do
+      with_settings(force_user_confirmation: true,
+                    mailer: { headers: { 'Sender': 'mail.sender@example.com', 'X-Something': 'yes' }}) do
         post users_path, params: {
           user: {
             username: 'mileyfan1997',
@@ -39,7 +37,5 @@ class DeviseMailerTest < ActionDispatch::IntegrationTest
     assert_equal 'no-reply@example.com', email_headers['From']
     assert_equal 'mail.sender@example.com', email_headers['Sender']
     assert_equal 'yes', email_headers['X-Something']
-  ensure
-    TeSS::Config.mailer = mailer_settings
   end
 end

--- a/test/mailers/curation_mailer_test.rb
+++ b/test/mailers/curation_mailer_test.rb
@@ -67,17 +67,15 @@ class CurationMailerTest < ActionMailer::TestCase
   end
 
   test 'can set mailer headers in config' do
-    mailer_settings = TeSS::Config.mailer
-    TeSS::Config.mailer['headers'] = { 'Sender' => 'mail.sender@example.com', 'X-Something' => 'yes' }
-    email = CurationMailer.user_requires_approval(@user)
+    with_settings(mailer: { headers: { 'Sender': 'mail.sender@example.com', 'X-Something': 'yes' }}) do
+      email = CurationMailer.user_requires_approval(@user)
 
-    email_headers = {}
-    email.header.fields.each { |f| email_headers[f.name] = f.value }
+      email_headers = {}
+      email.header.fields.each { |f| email_headers[f.name] = f.value }
 
-    assert_equal 'no-reply@example.com', email_headers['From']
-    assert_equal 'mail.sender@example.com', email_headers['Sender']
-    assert_equal 'yes', email_headers['X-Something']
-  ensure
-    TeSS::Config.mailer = mailer_settings
+      assert_equal 'no-reply@example.com', email_headers['From']
+      assert_equal 'mail.sender@example.com', email_headers['Sender']
+      assert_equal 'yes', email_headers['X-Something']
+    end
   end
 end

--- a/test/models/editor_test.rb
+++ b/test/models/editor_test.rb
@@ -217,9 +217,7 @@ class EditorTest < ActiveSupport::TestCase
   end
 
   test 'get_editable_providers' do
-    option = TeSS::Config.restrict_content_provider_selection
-    begin
-      TeSS::Config.restrict_content_provider_selection = true
+    with_settings(restrict_content_provider_selection: true) do
       curator = users(:curator)
       admin = users(:admin)
       owner = users(:another_regular_user)
@@ -248,15 +246,11 @@ class EditorTest < ActiveSupport::TestCase
       assert_includes editor.get_editable_providers, provider
       assert_not_includes editor.get_editable_providers, provider2
       assert_not_includes editor.get_editable_providers, provider3
-    ensure
-      TeSS::Config.restrict_content_provider_selection = option
     end
   end
 
   test 'get_editable_providers with unrestricted provider selection' do
-    option = TeSS::Config.restrict_content_provider_selection
-    begin
-      TeSS::Config.restrict_content_provider_selection = false
+    with_settings(restrict_content_provider_selection: false) do
       curator = users(:curator)
       admin = users(:admin)
       owner = users(:another_regular_user)
@@ -285,8 +279,6 @@ class EditorTest < ActiveSupport::TestCase
       assert_includes editor.get_editable_providers, provider
       assert_includes editor.get_editable_providers, provider2
       assert_includes editor.get_editable_providers, provider3
-    ensure
-      TeSS::Config.restrict_content_provider_selection = option
     end
   end
 

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -255,17 +255,13 @@ class EventTest < ActiveSupport::TestCase
   end
 
   test 'does not throw error when blocked domains list is blank' do
-    domains = TeSS::Config.blocked_domains
-    begin
-      TeSS::Config.blocked_domains = nil
+    with_settings(blocked_domains: nil) do
       assert_nothing_raised do
         parameters = @mandatory.merge({ user: users(:regular_user), title: 'Bad event', url: 'https://bad-domain.example/event',
                                         description: 'event for does not throw error when blocked domains list is blank',
                                         online: true })
         Event.create!(parameters)
       end
-    ensure
-      TeSS::Config.blocked_domains = domains
     end
   end
 

--- a/test/models/source_test.rb
+++ b/test/models/source_test.rb
@@ -87,18 +87,16 @@ class SourceTest < ActiveSupport::TestCase
   end
 
   test 'source approval status is set to approved by default if source_approval disabled' do
-    features = TeSS::Config.feature.dup
-    TeSS::Config.feature['user_source_creation'] = false
-    refute TeSS::Config.feature['user_source_creation']
-    User.current_user = users(:regular_user)
-    source = Source.new(content_provider: content_providers(:portal_provider),
-                        url: 'https://website.org',
-                        method: 'bioschemas',
-                        user: User.current_user)
-    assert source.save
-    assert_equal :approved, source.approval_status
-  ensure
-    TeSS::Config.feature = features
+    with_settings(feature: { user_source_creation: false }) do
+      refute TeSS::Config.feature['user_source_creation']
+      User.current_user = users(:regular_user)
+      source = Source.new(content_provider: content_providers(:portal_provider),
+                          url: 'https://website.org',
+                          method: 'bioschemas',
+                          user: User.current_user)
+      assert source.save
+      assert_equal :approved, source.approval_status
+    end
   end
 
   test 'changes to approval status are logged' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -23,13 +23,17 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'default role should be configurable' do
-    default_role = TeSS::Config.default_role
-    begin
-      TeSS::Config.default_role = 'basic_user'
+    with_settings(default_role: 'basic_user') do
       user = User.create!(@user_params)
       assert_equal 'basic_user', user.role.name
-    ensure
-      TeSS::Config.default_role = default_role
+    end
+
+    with_settings(default_role: 'unverified_user') do
+      user = User.create!({ username: 'new_user2',
+                            password: '12345678',
+                            email: 'new-user2@example.com',
+                            processing_consent: '1' })
+      assert_equal 'unverified_user', user.role.name
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -49,9 +49,15 @@ class ActiveSupport::TestCase
   # Add more helper methods to be used by all tests here...
 
   # Temporarily change TeSS config for the duration of the block
-  def with_settings(settings, &block)
+  def with_settings(settings, overwrite = false, &block)
     orig_config = TeSS::Config.to_h
-    settings.each { |k, v| TeSS::Config[k] = v }
+    settings.each do |k, v|
+      if !overwrite && TeSS::Config[k].is_a?(Hash) && v.is_a?(Hash)
+        TeSS::Config[k] = v.with_indifferent_access.reverse_merge!(TeSS::Config[k])
+      else
+        TeSS::Config[k] = v
+      end
+    end
     block.call
   ensure
     orig_config.each { |k, v| TeSS::Config[k] = v }


### PR DESCRIPTION
**Summary of changes**

- Updates tests to consistently use the `with_settings` helper method to apply temporary changes to TeSS' config instead of manual setting and reverting config using `ensure`.

**Motivation and context**

Consistently using the same method makes it easier to make changes in the future.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
