### PR TITLE
Fix error pages not being renderer. Fixes #797

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,26 +38,18 @@ class ApplicationController < ActionController::Base
     if status_code.is_a?(Symbol) # Convert :forbidden, :not_found, etc. to 403, 404 etc.
       status_code = Rack::Utils::SYMBOL_TO_STATUS_CODE[status_code] || status_code
     end
-    status_code = status_code.to_i
-    @skip_flash_messages_in_header = true
 
     if message.blank?
-      case status_code
-      when 500
-        message = 'Our apologies - your request caused an error (status code: 500 Server Error).'
-      when 503
-        message = 'Our apologies - the server is temporarily down or unavailable due to maintenance (status code: 503 Service Unavailable).'
-      when 422
-        message = 'The request you sent was well-formed but the change you wanted was rejected (status code: 422 Unprocessable Entity).'
-      when 404
-        message = 'The requested page could not be found - you may have mistyped the address or the page may have moved (status code: 404 Not Found).'
-      end
+      message = t("errors.#{status_code}",
+                  default: "#{TeSS::Config.site['title_short']} encountered an unexpected error: #{status_code}")
     end
 
-    flash[:alert] = message
+    status_code = status_code.to_i
+    @message = message
     respond_to do |format|
       format.html  { render 'static/error', status: status_code}
       format.json { render json: { error: { message: message, code: status_code } }, status: status_code }
+      format.json_api { render json: { error: { message: message, code: status_code } }, status: status_code }
     end
   end
 

--- a/app/views/static/error.html.erb
+++ b/app/views/static/error.html.erb
@@ -1,7 +1,3 @@
-<%# The layout will render the header and footer, so we just display the flash messages. %>
-
-<div class="row">
-    <div id="flash-container">
-        <%= flash_messages %>
-    </div>
+<div id="error-message" class="alert alert-danger mt-5">
+  <%= raw @message %>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,6 +37,8 @@ module TeSS
       Symbol, Date, Time, ActiveSupport::TimeWithZone, ActiveSupport::TimeZone,
       ActiveSupport::HashWithIndifferentAccess, BigDecimal
     ]
+
+    config.exceptions_app = self.routes
   end
 
   tess_config = Rails.configuration.tess.with_indifferent_access

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -492,3 +492,8 @@ en:
     categories:
       user: Owner
       organizer: Organiser
+  errors:
+    500: "Apologies, TeSS encountered an error whilst handling your request (500 Internal Server Error)."
+    503: "Apologies, TeSS is temporarily down or unavailable due to maintenance (503 Service Unavailable)."
+    422: "The request you sent was well-formed but the change you wanted was rejected (422 Unprocessable Entity)."
+    404: "The requested page could not be found - you may have mistyped the address or the page may have moved (404 Not Found)."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -135,7 +135,7 @@ Rails.application.routes.draw do
 
   # error pages
   %w( 404 422 500 503 ).each do |code|
-    get code, :to => "application#handle_error", :status_code => code
+    get code, to: 'application#handle_error', status_code: code
   end
 
   get 'curate/topic_suggestions' => 'curator#topic_suggestions'

--- a/test/controllers/curator_controller_test.rb
+++ b/test/controllers/curator_controller_test.rb
@@ -37,7 +37,7 @@ class CuratorControllerTest < ActionController::TestCase
     get :topic_suggestions
 
     assert_response :forbidden
-    assert flash[:alert].include?('curator')
+    assert_select '#error-message', text: /curator/
     assert_nil assigns(:suggestions)
   end
 
@@ -99,7 +99,7 @@ class CuratorControllerTest < ActionController::TestCase
     get :users
 
     assert_response :forbidden
-    assert flash[:alert].include?('curator')
+    assert_select '#error-message', text: /curator/
     assert_nil assigns(:suggestions)
   end
 

--- a/test/integration/error_handler_test.rb
+++ b/test/integration/error_handler_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+class ErrorHandlerTest < ActionDispatch::IntegrationTest
+  ERRORS = {
+    404 => /could not be found/,
+    422 => /change you wanted was rejected/,
+    500 => /TeSS encountered an error/,
+    503 => /TeSS is temporarily down/
+  }
+
+  ERRORS.each do |code, message_matcher|
+    test "should get #{code} error as html" do
+      get "/#{code}", as: :html
+
+      assert_response code
+      assert_select '#error-message', text: message_matcher
+    end
+
+    test "should get #{code} error as json" do
+      get "/#{code}", as: :json
+
+      assert_response code
+      assert_match message_matcher, JSON.parse(response.body).dig('error', 'message')
+    end
+
+    test "should get #{code} error as json-api" do
+      get "/#{code}", headers: { 'Accept': 'application/vnd.api+json' }
+
+      assert_response code
+      assert_match message_matcher, JSON.parse(response.body).dig('error', 'message')
+    end
+  end
+end

--- a/test/integration/identifier_resolution_test.rb
+++ b/test/integration/identifier_resolution_test.rb
@@ -57,7 +57,7 @@ class IdentifierResolutionTest < ActionDispatch::IntegrationTest
 
     assert_response :bad_request
 
-    assert_select '#flash-container .alert', /Unrecognized type/
+    assert_select '#error-message', text: /Unrecognized type/
   end
 
   test 'does not resolve missing resource' do


### PR DESCRIPTION
**Summary of changes**

- Renders appropriate pages when an error occurs.
- Uses I18n for error messages so they can be customised.

**Motivation and context**

#797 

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
