### PR TITLE
Configurable number of providers in carousel on home page

### DIFF
--- a/app/views/static/home/_provider_carousel.html.erb
+++ b/app/views/static/home/_provider_carousel.html.erb
@@ -1,7 +1,7 @@
 <% per_slide = 3 %>
 <% return unless TeSS::Config.feature['content_providers'] %>
 <% provider_ids = TeSS::Config.site.dig('home_page', 'featured_providers') %>
-<% provider_ids = ContentProvider.where.not(image_file_size: nil).last(5).pluck(:id) if provider_ids.nil? %>
+<% provider_ids = ContentProvider.where.not(image_file_size: nil).last(TeSS::Config.site['n_provider_ids']).pluck(:id) if provider_ids.nil? %>
 <% return if provider_ids.blank? %>
 
 <% cache(['home', 'provider-carousel', provider_ids.join('-')]) do %>

--- a/config/tess.example.yml
+++ b/config/tess.example.yml
@@ -39,6 +39,7 @@ default: &default
     tab_order: ['about', 'events', 'materials', 'elearning_materials', 'workflows', 'collections', 'trainers', 'content_providers', 'nodes']
     # The tabs that should be collapsed under the "Directory" tab. Can be left blank to hide it.
     directory_tabs: ['trainers', 'content_providers', 'nodes']
+    n_provider_ids: 5
   mailer:
     delivery_method: sendmail
     location: /usr/sbin/sendmail


### PR DESCRIPTION
**Summary of changes**
Changed the number of providers appearing in the carroussel to a config variable

**Motivation and context**
We want to change this number in the Taxila fork. This is a non-intrusive way of doing so while also getting rid of a hard coded variable in the main Tess branch.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
