### PR TITLE
Hide unverified users' providers from carousel

### DIFF
--- a/app/views/static/home/_provider_carousel.html.erb
+++ b/app/views/static/home/_provider_carousel.html.erb
@@ -1,7 +1,7 @@
 <% per_slide = 3 %>
 <% return unless TeSS::Config.feature['content_providers'] %>
 <% provider_ids = TeSS::Config.site.dig('home_page', 'featured_providers') %>
-<% provider_ids = ContentProvider.where.not(image_file_size: nil).last(5).pluck(:id) if provider_ids.nil? %>
+<% provider_ids = ContentProvider.from_verified_users.where.not(image_file_size: nil).last(5).pluck(:id) if provider_ids.nil? %>
 <% return if provider_ids.blank? %>
 
 <% cache(['home', 'provider-carousel', provider_ids.join('-')]) do %>

--- a/test/controllers/static_controller_test.rb
+++ b/test/controllers/static_controller_test.rb
@@ -189,4 +189,27 @@ class StaticControllerTest < ActionController::TestCase
       end
     end
   end
+
+  test 'should hide unverified providers from carousel' do
+    mock_images
+    ContentProvider.destroy_all
+    regular = users(:regular_user)
+    unverified = users(:unverified_user)
+    regular_provider = regular.content_providers.create!(title: 'Regular Provider',
+                                                         image_url: 'http://example.com/goblet.png',
+                                                         url: 'https://providers.com/p1')
+    unverified_provider = unverified.content_providers.create!(title: 'Unverified Provider',
+                                                               image_url: 'http://example.com/goblet.png',
+                                                               url: 'https://providers.com/p2')
+    another_provider = regular.content_providers.create!(title: 'Another Regular Provider',
+                                                         image_url: 'http://example.com/goblet.png',
+                                                         url: 'https://providers.com/p3')
+    with_settings(site: { home_page: { provider_carousel: true } }) do
+      get :home
+      assert_select 'section#providers .item', count: 2
+      assert_select 'section#providers .item a[href=?]', content_provider_path(regular_provider)
+      assert_select 'section#providers .item a[href=?]', content_provider_path(unverified_provider), count: 0
+      assert_select 'section#providers .item a[href=?]', content_provider_path(another_provider)
+    end
+  end
 end


### PR DESCRIPTION
**Summary of changes**

- Adds the `from_verified_users` filter to the provider selection that is used in the carousel on the front page (when no explicit provider IDs are specified).

**Motivation and context**

A spam provider was showing up, and this is likely to happen again as it shows the most recent providers.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
