### PR TITLE
Relocate keywords that belong to other variables when scraping

### DIFF
--- a/app/dictionaries/online_keywords_dictionary.rb
+++ b/app/dictionaries/online_keywords_dictionary.rb
@@ -1,0 +1,12 @@
+# Dictionary of Eligibility for Event categories
+class OnlineKeywordsDictionary < Dictionary
+
+  DEFAULT_FILE = 'online_keywords.yml'
+
+  private
+
+  def dictionary_filepath
+    get_file_path 'online_keywords', DEFAULT_FILE
+  end
+
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -453,11 +453,13 @@ class Event < ApplicationRecord
     fix_online if !self&.online.present?
 
     [
-      [TargetAudienceDictionary, 'target_audience'],
-      [EventTypeDictionary, 'event_types'],
-      [EligibilityDictionary, 'eligibility'],
+      [TargetAudienceDictionary, :target_audience],
+      [EventTypeDictionary, :event_types],
+      [EligibilityDictionary, :eligibility],
     ].each do |dict, var|
-      self[var] ||= []
+      if not self[var].present?
+        self[var] = []
+      end
       dic = dict.instance
       self&.keywords&.dup&.each do |kw|
         res = dic.best_match(kw)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -441,8 +441,8 @@ class Event < ApplicationRecord
     dic.keys.each do |key|
       downcased_var = self[key]&.downcase
       dic.lookup(key).each do |v|
-        if downcased_var.include?(v)
-          self.online = True
+        if downcased_var&.include?(v)
+          self.online = true
           return
         end
       end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -437,11 +437,11 @@ class Event < ApplicationRecord
   end
 
   def fix_online(min_sim=0.3)
-    dic = OnlineKeywordsDictionary.instance.load_dictionary
-    dic.each do |var, v|
-      downcased_var = self[var].downcase
-      v.each do |kw, val|
-        if downcased_var.include?(val['title'])
+    dic = OnlineKeywordsDictionary.instance
+    dic.keys.each do |key|
+      downcased_var = self[key].downcase
+      dic.lookup(key).each do |k, v|
+        if downcased_var.include?(v['title'])
           self.online = True
           return
         end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -18,7 +18,7 @@ class Event < ApplicationRecord
   include FuzzyDictionaryMatch
   include WithTimezone
 
-  before_validation_on_create :fix_keywords, if: :scraper_record
+  before_validation :fix_keywords, on: :create, if: :scraper_record
   before_save :check_country_name # :set_default_times
   before_save :geocoding_cache_lookup, if: :address_will_change?
   after_save :enqueue_geocoding_worker, if: :address_changed?

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -18,7 +18,7 @@ class Event < ApplicationRecord
   include FuzzyDictionaryMatch
   include WithTimezone
 
-  before_save :fix_keywords
+  before_validation_on_create :fix_keywords, if: :scraper_record
   before_save :check_country_name # :set_default_times
   before_save :geocoding_cache_lookup, if: :address_will_change?
   after_save :enqueue_geocoding_worker, if: :address_changed?
@@ -436,7 +436,7 @@ class Event < ApplicationRecord
     datetime
   end
 
-  def fix_online(min_sim=0.3)
+  def fix_online
     dic = OnlineKeywordsDictionary.instance
     dic.keys.each do |key|
       downcased_var = self[key]&.downcase

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -439,9 +439,9 @@ class Event < ApplicationRecord
   def fix_online(min_sim=0.3)
     dic = OnlineKeywordsDictionary.instance
     dic.keys.each do |key|
-      downcased_var = self[key].downcase
-      dic.lookup(key).each do |k, v|
-        if downcased_var.include?(v['title'])
+      downcased_var = self[key]&.downcase
+      dic.lookup(key).each do |v|
+        if downcased_var.include?(v)
           self.online = True
           return
         end
@@ -450,17 +450,16 @@ class Event < ApplicationRecord
   end
 
   def fix_keywords
-    fix_online if !self.online.present?
+    fix_online if !self&.online.present?
 
-    keywords = self.keywords.dup
-    dicts = [
+    [
       [TargetAudienceDictionary, 'target_audience'],
       [EventTypeDictionary, 'event_types'],
       [EligibilityDictionary, 'eligibility'],
-    ]
-    dicts.each do |dict, var|
+    ].each do |dict, var|
+      self[var] ||= []
       dic = dict.instance
-      keywords.each do |kw|
+      self&.keywords&.dup&.each do |kw|
         res = dic.best_match(kw)
         if res
           self[var].append(kw)

--- a/config/dictionaries/online_keywords.yml
+++ b/config/dictionaries/online_keywords.yml
@@ -1,0 +1,18 @@
+description:
+  webinar:
+    title: 'webinar'
+  zoom:
+    title: 'zoom'
+  ms_teams:
+    title: 'ms teams'
+  online_workshop:
+    title: 'online workshop'
+venue:
+  webinar:
+    title: 'webinar'
+  zoom:
+    title: 'zoom'
+  ms_teams:
+    title: 'teams'
+  online_workshop:
+    title: 'online'

--- a/config/dictionaries/online_keywords.yml
+++ b/config/dictionaries/online_keywords.yml
@@ -1,18 +1,10 @@
 description:
-  webinar:
-    title: 'webinar'
-  zoom:
-    title: 'zoom'
-  ms_teams:
-    title: 'ms teams'
-  online_workshop:
-    title: 'online workshop'
+  - webinar
+  - zoom
+  - ms_teams
+  - online workshop
 venue:
-  webinar:
-    title: 'webinar'
-  zoom:
-    title: 'zoom'
-  ms_teams:
-    title: 'teams'
-  online_workshop:
-    title: 'online'
+  - webinar
+  - zoom
+  - teams
+  - online

--- a/config/tess.example.yml
+++ b/config/tess.example.yml
@@ -87,6 +87,7 @@ default: &default
     material_type: 'material_type.yml'
     target_audience: 'target_audience.yml'
     trainer_experience: 'trainer_experience.yml'
+    online_keywords: 'online_keywords.yml'
   funders:
 #    - url: https://example.com/your-funders-website
 #      logo: foo.png

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -452,18 +452,20 @@ class EventTest < ActiveSupport::TestCase
 
   test 'get online status from description if scraped' do
     event = Event.new(title: 'An event', timezone: 'UTC', user: users(:regular_user), url: 'https://https-website.com/mat', description: 'This event is held on Zoom', scraper_record: true)
-    assert event.valid?
     assert_not event.online
+    assert event.valid?
     event.save!
     assert event.online
   end
 
   test 'get event_type from keywords if scraped' do
     event = Event.new(title: 'An event', timezone: 'UTC', user: users(:regular_user), url: 'https://https-website.com/mat', keywords: ['Workshops and courses'], scraper_record: true)
-    assert event.valid?
     assert_not event.event_types.include?('Workshops and courses')
+    assert event.keywords.include?('Workshops and courses')
+    assert event.valid?
     event.save!
     assert event.event_types.include?('Workshops and courses')
+    assert_not event.keywords.include?('Workshops and courses')
   end
 
   test 'do not get event_type from keywords if not scraped' do

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -464,11 +464,7 @@ class EventTest < ActiveSupport::TestCase
     assert event.keywords.include?('Workshops and courses')
     assert event.valid?
     event.save!
-    puts 'hi'
-    puts event.event_types
-    puts event.keywords
-    puts 'ho'
-    assert event.event_types.include?('Workshops and courses')
+    assert event.event_types.include?('workshops_and_courses')
     assert_not event.keywords.include?('Workshops and courses')
   end
 

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -449,4 +449,21 @@ class EventTest < ActiveSupport::TestCase
     assert event.valid?
     assert_equal [event_type], event.event_types
   end
+
+  test 'get online status from description' do
+    event = Event.new(title: 'An event', timezone: 'UTC', user: users(:regular_user), url: 'https://https-website.com/mat', description: 'This event is held on Zoom')
+    assert event.valid?
+    assert_not event.online
+    event.save!
+    assert event.online
+  end
+
+  test 'get event_type from keywords' do
+    event = Event.new(title: 'An event', timezone: 'UTC', user: users(:regular_user), url: 'https://https-website.com/mat', keywords: ['Workshops and courses'])
+    assert event.valid?
+    assert_not event.event_types.include?('Workshops and courses')
+    event.save!
+    assert event.event_types.include?('Workshops and courses')
+  end
+
 end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -450,20 +450,28 @@ class EventTest < ActiveSupport::TestCase
     assert_equal [event_type], event.event_types
   end
 
-  test 'get online status from description' do
-    event = Event.new(title: 'An event', timezone: 'UTC', user: users(:regular_user), url: 'https://https-website.com/mat', description: 'This event is held on Zoom')
+  test 'get online status from description if scraped' do
+    event = Event.new(title: 'An event', timezone: 'UTC', user: users(:regular_user), url: 'https://https-website.com/mat', description: 'This event is held on Zoom', scraper_record: true)
     assert event.valid?
     assert_not event.online
     event.save!
     assert event.online
   end
 
-  test 'get event_type from keywords' do
-    event = Event.new(title: 'An event', timezone: 'UTC', user: users(:regular_user), url: 'https://https-website.com/mat', keywords: ['Workshops and courses'])
+  test 'get event_type from keywords if scraped' do
+    event = Event.new(title: 'An event', timezone: 'UTC', user: users(:regular_user), url: 'https://https-website.com/mat', keywords: ['Workshops and courses'], scraper_record: true)
     assert event.valid?
     assert_not event.event_types.include?('Workshops and courses')
     event.save!
     assert event.event_types.include?('Workshops and courses')
+  end
+
+  test 'do not get event_type from keywords if not scraped' do
+    event = Event.new(title: 'An event', timezone: 'UTC', user: users(:regular_user), url: 'https://https-website.com/mat', keywords: ['Workshops and courses'], scraper_record: false)
+    assert event.valid?
+    event.save!
+    assert_not event.event_types.include?('Workshops and courses')
+    assert event.keywords.include?('Workshops and courses')
   end
 
 end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -464,6 +464,10 @@ class EventTest < ActiveSupport::TestCase
     assert event.keywords.include?('Workshops and courses')
     assert event.valid?
     event.save!
+    puts 'hi'
+    puts event.event_types
+    puts event.keywords
+    puts 'ho'
     assert event.event_types.include?('Workshops and courses')
     assert_not event.keywords.include?('Workshops and courses')
   end

--- a/test/unit/ingestors/eventbrite_ingestor_test.rb
+++ b/test/unit/ingestors/eventbrite_ingestor_test.rb
@@ -93,10 +93,12 @@ class EventbriteIngestorTest < ActiveSupport::TestCase
     assert_equal 1, event.event_types.size
     assert_includes event.event_types, 'meetings_and_conferences'
     refute_empty event.keywords
-    assert_equal 2, event.keywords.size
-    assert_includes event.keywords, 'Business & Professional'
+    assert_equal 1, event.keywords.size
+    refute_includes event.keywords, 'Business & Professional'
     assert_includes event.keywords, 'Other'
     refute_includes event.keywords, 'Dummy'
+    assert_equal 1, event.target_audience.size
+    assert_includes event.target_audience, 'Business & Professional'
 
     # check ingested event
     # eventbrite.id: 315896965327


### PR DESCRIPTION
**Summary of changes**
Before event save, check whether any keywords are found in other dictionaries and put the values in the corresponding var.
Before event save, find whether event is online by scanning venue and description for entries from dictionaries

**Motivation and context**
Lots of scraped online events end up as face-to-face events because the provider does not have a good way to get the information directly.
 
**Screenshots**

(Paste or upload any relevant screenshots)

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
