### PR TITLE
Index `external resource` titles for text search

### DIFF
--- a/app/models/concerns/has_external_resources.rb
+++ b/app/models/concerns/has_external_resources.rb
@@ -10,14 +10,17 @@ module HasExternalResources
     if TeSS::Config.solr_enabled
       # :nocov:
       searchable do
+        text :related_resources do
+          external_resources.map(&:title)
+        end
         string :tools, multiple: true do
-          self.external_resources.select(&:is_tool?).collect(&:title)
+          external_resources.select(&:is_tool?).map(&:title)
         end
         string :standard_database_or_policy, multiple: true do
-          self.external_resources.select(&:is_fairsharing?).collect(&:title)
+          external_resources.select(&:is_fairsharing?).map(&:title)
         end
         string :related_resources, multiple: true do
-          self.external_resources.select(&:is_generic_external_resource?).collect(&:title)
+          external_resources.select(&:is_generic_external_resource?).map(&:title)
         end
       end
       # :nocov:


### PR DESCRIPTION
**Summary of changes**

- Make sure external resource titles are indexed for the text search, not just for faceting.

**Motivation and context**

@egonw discovered his materials were not findable via search after annotating with bio.tool tools.

Also, bio.tools is currently linking back to TeSS using the tool name in the text search query parameter (https://github.com/bio-tools/biotoolsRegistry/issues/80#issuecomment-1496227469), which would currently not find any tools unless they were mentioned in other metadata fields.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
