### PR TITLE
Fixes/improvements to scraping

### DIFF
--- a/lib/ingestors/ingestor_factory.rb
+++ b/lib/ingestors/ingestor_factory.rb
@@ -27,6 +27,10 @@ module Ingestors
       end
     end
 
+    def self.valid_ingestor?(method)
+      ingestor_config.key?(method)
+    end
+
     def self.grouped_options
       @grouped_options ||= ingestor_config.values.group_by { |c| c[:category] || :any }
     end

--- a/lib/scraper.rb
+++ b/lib/scraper.rb
@@ -20,6 +20,10 @@ class Scraper
         errors.delete(:content_provider)
       end
     end
+
+    def resource_type=(*args)
+      warn %(The "resource_type" property for a source is now redundant ("#{@provider}" in config/ingestion.yml))
+    end
   end
 
   attr_reader :log_file, :name, :username, :sources
@@ -59,6 +63,7 @@ class Scraper
       if user.role.nil? or user.role.name != @default_role
         log t('scraper.messages.invalid', error_message: t('scraper.messages.bad_role')), 1
       end
+      User.current_user = user
 
       processed = 0
 
@@ -146,7 +151,9 @@ class Scraper
 
     rescue Exception => e
       log "   Run Scraper failed with: #{e.message}", 0
-      log "       #{e.backtrace[0]}", 0
+      e.backtrace.each do |line|
+        log "       #{line}", 0
+      end
     end
 
     # wrap up

--- a/test/config/test_ingestion_crash.yml
+++ b/test/config/test_ingestion_crash.yml
@@ -1,0 +1,7 @@
+name: crash
+logfile: log/ingestion.test.log
+loglevel: 0
+username: ingestor
+sources:
+  - id: 1
+    jgrhierjvrv: gjigdfgidf

--- a/test/config/test_ingestion_legacy.yml
+++ b/test/config/test_ingestion_legacy.yml
@@ -1,0 +1,11 @@
+name: legacy
+logfile: log/ingestion.test.log
+loglevel: 0
+username: ingestor
+sources:
+  - id: 1
+    provider: 'Portal Provider'         # content provider's title
+    url: https://zenodo.org/api/records/?communities=ardc  # the root URL to access the source
+    method: rest                        # one of 'csv', 'rest'
+    resource_type: material
+    enabled: true


### PR DESCRIPTION
**Summary of changes**

* Don't crash the entire scraper task when loading legacy config
* Log full backtrace in case of crash
* Ensure all source methods are scraped, regardless of whether they are in the user-permitted set

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
