### PR TITLE
Case insensitive username/email validation

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -57,6 +57,24 @@ class Profile < ApplicationRecord
     "#{firstname} #{surname}".strip
   end
 
+  def merge(*others)
+    Profile.transaction do
+      attrs = attributes
+      others.each do |other|
+        other.attributes.each do |attr, value|
+          if value.is_a?(Array)
+            attrs[attr] ||= []
+            attrs[attr] |= value
+          elsif attrs[attr].blank?
+            attrs[attr] = value
+          end
+        end
+      end
+
+      self.update(attrs)
+    end
+  end
+
   private
 
   @@orcid_host = 'orcid.org'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,9 +66,7 @@ class User < ApplicationRecord
            :omniauthable, :authentication_keys => [:login]
   end
 
-  validates :username,
-            :presence => true,
-            :uniqueness => true
+  validates :username, presence: true, uniqueness: { case_sensitive: false }
 
   validate :consents_to_processing, on: :create, unless: ->(user) { user.using_omniauth? || User.current_user.try(:is_admin?) }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -186,7 +186,7 @@ class User < ApplicationRecord
 
     # find by provider and { uid or email}
     users = User.where(provider: auth.provider, uid: auth.uid)
-    if users.nil? or users.size <= 0
+    if users.none? && auth.info.email.present? && auth.provider.present?
       users = User.where(provider: auth.provider, email: auth.info.email)
     end
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -44,7 +44,7 @@ Devise.setup do |config|
   # Configure which authentication keys should be case-insensitive.
   # These keys will be downcased upon creating or modifying a user and when used
   # to authenticate or find a user. Default is :email.
-  config.case_insensitive_keys = [:login]
+  config.case_insensitive_keys = [:email]
 
   # Configure which authentication keys should have whitespace stripped.
   # These keys will have whitespace before and after removed upon creating or

--- a/test/controllers/curator_controller_test.rb
+++ b/test/controllers/curator_controller_test.rb
@@ -130,6 +130,7 @@ class CuratorControllerTest < ActionController::TestCase
     collection = nil
     provider = nil
     source = nil
+    node = nil
     4.times do |i|
       e = new_user.events.create!(title: "Spam event #{i}", url: "http://cool-event.pancakes/#{i}", start: 10.days.from_now,
                                   description: "test event", organizer: "test organizer", end: 11.days.from_now,
@@ -170,6 +171,12 @@ class CuratorControllerTest < ActionController::TestCase
       source = s
     end
 
+    4.times do |i|
+      n = new_user.nodes.create!(name: "Node#{i}", country_code: 'ES')
+      n.create_activity(:create, owner: new_user)
+      node = n
+    end
+
     get :users, params: { with_content: true }
 
     assert_response :success
@@ -184,7 +191,7 @@ class CuratorControllerTest < ActionController::TestCase
                     text: "See all 4 #{klass.model_name.human.pluralize}"
     end
 
-    [event, material, workflow, collection, provider, source].each do |resource|
+    [event, material, workflow, collection, provider, source, node].each do |resource|
       assert_select '.curate-user a[href=?]', @controller.polymorphic_path(resource), { text: resource.title },
                     "#{@controller.polymorphic_path(resource)} not found!, \nBody:\n#{response.body}"
     end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -146,3 +146,8 @@ existing_aai_user:
   provider: elixir_aai
   uid: 1234
 
+upcase_username_and_email:
+  username: 'MixedCaseUsername'
+  email: 'MixedCaseEmail@example.com'
+  encrypted_password: <%= Devise::Encryptor.digest(User, 'private') %>
+  confirmed_at: <%= Time.zone.now %>

--- a/test/integration/login_test.rb
+++ b/test/integration/login_test.rb
@@ -1,16 +1,6 @@
 require 'test_helper'
 
 class LoginTest < ActionDispatch::IntegrationTest
-
-  def login_user(username, identifier, password)
-    get '/users/sign_in'
-    post '/users/sign_in', params: { 'user[login]' => identifier, 'user[password]' => password }
-    follow_redirect!
-    assert_equal '/', path
-    assert_select '#user-menu .dropdown-toggle', username
-    assert_equal 'Logged in successfully.', flash[:notice]
-  end
-
   test 'can log in with username' do
     user = users(:regular_user)
     login_user(user.username, user.username, 'hello')
@@ -21,4 +11,40 @@ class LoginTest < ActionDispatch::IntegrationTest
     login_user(user.username, user.email, 'hello')
   end
 
+  test 'can log in case insensitively' do
+    user = User.create!(username: 'neWuSer1996', email: 'neWUSer1996@email.com', password: '12345678',
+                        processing_consent: '1')
+
+    login_user(user.username, 'neWuSer1996', '12345678')
+    logout_user
+    login_user(user.username, 'NEWUSER1996', '12345678')
+    logout_user
+    login_user(user.username, 'newuser1996', '12345678')
+    logout_user
+    login_user(user.username, 'neWUSer1996@email.com', '12345678')
+    logout_user
+    login_user(user.username, 'NEWUSER1996@email.com', '12345678')
+    logout_user
+    login_user(user.username, 'newuser1996@email.com', '12345678')
+    logout_user
+  end
+
+  private
+
+  def login_user(username, identifier, password)
+    get '/users/sign_in'
+    post '/users/sign_in', params: { 'user[login]' => identifier, 'user[password]' => password }
+    follow_redirect!
+    assert_equal '/', path
+    assert_select '#user-menu .dropdown-toggle', username
+    assert_equal 'Logged in successfully.', flash[:notice]
+  end
+
+  def logout_user
+    delete '/users/sign_out'
+    follow_redirect!
+    assert_equal '/', path
+    assert_select '#navbar-collapse .dropdown-toggle strong', 'Log In'
+    assert_equal 'Logged out successfully.', flash[:notice]
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -249,4 +249,34 @@ class UserTest < ActiveSupport::TestCase
     assert_includes User.with_query('basic'), basic
     assert_not_includes User.with_role('registered_user').with_query('basic'), basic
   end
+
+  test 'reassigns resources when deleted' do
+    user = users(:regular_user)
+    event = events(:one)
+    material = materials(:good_material)
+    workflow = workflows(:one)
+    content_provider = content_providers(:goblet)
+    source = sources(:unapproved_source)
+    collection = collections(:one)
+    node = nodes(:good)
+
+    assert_equal user, event.user
+    assert_equal user, material.user
+    assert_equal user, workflow.user
+    assert_equal user, content_provider.user
+    assert_equal user, source.user
+    assert_equal user, collection.user
+    assert_equal user, node.user
+
+    user.destroy!
+
+    default_user = User.get_default_user
+    assert_equal default_user, event.reload.user
+    assert_equal default_user, material.reload.user
+    assert_equal default_user, workflow.reload.user
+    assert_equal default_user, content_provider.reload.user
+    assert_equal default_user, source.reload.user
+    assert_equal default_user, collection.reload.user
+    assert_equal default_user, node.reload.user
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -95,6 +95,15 @@ class UserTest < ActiveSupport::TestCase
     user2 = User.new(@user_params.merge(email: "#{@user_data.email}1"))
     assert user1.save, 'Did not save the first user'
     assert_not user2.save, 'Saved the second user with same username as first'
+    assert user2.errors.added?(:username, :taken, value: @user_params[:username])
+  end
+
+  test "should not save two users with same case insensitive username" do
+    user1 = User.new(@user_params.merge(email: "#{@user_data.email}2"))
+    user2 = User.new(@user_params.merge(email: "#{@user_data.email}1", username: @user_params[:username].upcase))
+    assert user1.save, 'Did not save the first user'
+    assert_not user2.save, 'Saved the second user with same username as first'
+    assert user2.errors.added?(:username, :taken, value: @user_params[:username].upcase)
   end
 
   test "should not save two users with same email" do
@@ -102,6 +111,15 @@ class UserTest < ActiveSupport::TestCase
     user2 = User.new(@user_params.merge(username: "#{@user_data.username}1"))
     assert user1.save, 'Did not save the first user'
     assert_not user2.save, 'Saved a second user with same e-mail address'
+    assert user2.errors.added?(:email, :taken, value: @user_params[:email])
+  end
+
+  test "should not save user with case insensitive duplicate email" do
+    user1 = User.new(@user_params.merge(username: "#{@user_data.username}2"))
+    user2 = User.new(@user_params.merge(username: "#{@user_data.username}1", email: @user_params[:email].upcase))
+    assert user1.save, 'Did not save the first user'
+    assert_not user2.save, 'Saved a second user with same e-mail address'
+    assert user2.errors.added?(:email, :taken, value: @user_params[:email])
   end
 
   test 'should destroy user' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -279,4 +279,92 @@ class UserTest < ActiveSupport::TestCase
     assert_equal default_user, collection.reload.user
     assert_equal default_user, node.reload.user
   end
+
+  test 'merge users' do
+    user1 = User.create!(username: 'base_user', password: '12345678', email: 'base-user@example.com',
+                         processing_consent: '1', profile_attributes: {
+        expertise_technical: ['Python', 'Ruby', 'R'],
+        firstname: 'John', surname: 'Userton'
+      })
+    user1_id = user1.id
+    user2 = User.create!(username: 'merge_user', password: 'xyz123456', email: 'merge-user@example.com',
+                         processing_consent: '1', profile_attributes: {
+        firstname: 'J', surname: 'U',
+        expertise_technical: ['Java', 'Python', 'R'],
+        orcid: 'https://orcid.org/0000-0002-1825-0097'
+      })
+    user3 = User.create!(username: 'merge_user2', password: 'qwertyqwerty', email: 'merge-user2@example.com',
+                         processing_consent: '1', profile_attributes: {
+        orcid: 'https://orcid.org/0000-0001-9842-9718',
+        description: 'Cool guy',
+        expertise_technical: []
+      })
+
+    # Resources
+    material1 = user1.materials.create!(title: 'material 1', url: 'https://training.com/materials/1', description: 'material1')
+    material2 = user2.materials.create!(title: 'material 2', url: 'https://training.com/materials/2', description: 'material2')
+    event1 = user2.events.create!(title: 'event 1', url: 'https://training.com/events/1')
+    event2 = user3.events.create!(title: 'event 2', url: 'https://training.com/events/2')
+
+    # Activity
+    admin = users(:admin)
+    User.current_user = admin
+    assert_difference('PublicActivity::Activity.count', 1) do
+      assert user2.update(role_id: Role.rejected.id)
+    end
+    activity1 = PublicActivity::Activity.last # As trackable
+    assert_equal admin, activity1.owner
+    assert_equal user2, activity1.trackable
+    activity2 = event2.create_activity(:create, owner: user3) # As owner
+    assert_equal user3, activity2.owner
+    assert_equal event2, activity2.trackable
+
+    # Subscriptions
+    subscription1 = user2.subscriptions.create!(frequency: :daily, query: 'test', subscribable_type: 'Material')
+    subscription2 = user2.subscriptions.create!(frequency: :weekly, query: 'test', subscribable_type: 'Event')
+
+    # Approved editors
+    provider = content_providers(:goblet)
+    provider.add_editor(user1)
+    provider.add_editor(user2)
+
+    # Collaborations
+    workflow1 = workflows(:one)
+    workflow2 = workflows(:two)
+    workflow1.collaborators << user1
+    workflow1.collaborators << user2
+    workflow2.collaborators << user3
+
+
+    # Test
+    assert user1.merge(user2, user3)
+    assert user2.reload.destroy
+    assert user3.reload.destroy
+
+    assert_equal 'base_user', user1.username
+    assert_equal user1_id, user1.id
+    assert_equal 'base-user@example.com', user1.email
+    profile = user1.profile
+    assert_equal 'John', profile.firstname
+    assert_equal 'Userton', profile.surname
+    assert_equal 'https://orcid.org/0000-0002-1825-0097', profile.orcid
+    assert_equal 'Cool guy', profile.description
+    assert_equal ['Python', 'Ruby', 'R', 'Java'], profile.expertise_technical
+
+    assert_includes user1.materials, material1
+    assert_includes user1.materials, material2
+    assert_includes user1.events, event2
+    assert_includes user1.events, event2
+
+    assert_equal user1, activity1.reload.trackable
+    assert_equal user1, activity2.reload.owner
+
+    assert_equal user1, subscription1.reload.user
+    assert_equal user1, subscription2.reload.user
+
+    assert_includes provider.reload.editors, user1
+
+    assert_equal [user1], workflow1.reload.collaborators.to_a
+    assert_equal [user1], workflow2.reload.collaborators.to_a
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -53,8 +53,9 @@ class ActiveSupport::TestCase
 
   # Temporarily change TeSS config for the duration of the block
   def with_settings(settings, overwrite = false, &block)
-    orig_config = TeSS::Config.to_h
+    orig_config = {}
     settings.each do |k, v|
+      orig_config[k] = TeSS::Config[k]
       if !overwrite && TeSS::Config[k].is_a?(Hash) && v.is_a?(Hash)
         TeSS::Config[k] = v.with_indifferent_access.reverse_merge!(TeSS::Config[k])
       else


### PR DESCRIPTION
**Summary of changes**

- Prevent registration with the same username/email address using different cases
- Re-assign workflows and collections to the default user if a user is deleted (as with other resource types)
- Add a method to merge user accounts

**Motivation and context**

Discovered a user in production with multiple accounts using the same email address, but with different cases.

#829 

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
