### PR TITLE
Fix issue reindexing collection with content. Fixes #841

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -16,12 +16,8 @@ class Collection < ApplicationRecord
   # Remove trailing and squeezes (:squish option) white spaces inside the string (before_validation):
   # e.g. "James     Bond  " => "James Bond"
   auto_strip_attributes :title, :description, :image_url, :squish => false
-  after_save do
-    index_items if saved_change_to_title?
-  end
-  after_destroy do
-    index_items
-  end
+
+  after_commit :index_items, if: :title_previously_changed?
 
   validates :title, presence: true
 
@@ -97,6 +93,6 @@ class Collection < ApplicationRecord
   def index_items
     return unless TeSS::Config.solr_enabled
 
-    items.each(&:solr_index)
+    items.each(&:reindex_resource)
   end
 end

--- a/test/models/collection_test.rb
+++ b/test/models/collection_test.rb
@@ -1,6 +1,28 @@
 require 'test_helper'
 
 class CollectionTest < ActiveSupport::TestCase
+  teardown do
+    DummyMaterial.clear_index!
+  end
+
+  class DummyMaterial < ::Material
+    def self.index
+      (@index ||= Hash.new).values.flatten.uniq
+    end
+
+    def self.add_to_index(m)
+      index
+      @index[m.id] = m.reload.collections.to_a
+    end
+
+    def self.clear_index!
+      @index = Hash.new
+    end
+
+    def solr_index
+      self.class.add_to_index(self)
+    end
+  end
 
   test 'visibility scope' do
     assert_not_includes Collection.visible_by(nil), collections(:secret_collection)
@@ -90,6 +112,50 @@ class CollectionTest < ActiveSupport::TestCase
 
     assert_difference('CollectionItem.count', -2) do
       assert collection.destroy
+    end
+  end
+
+  test 'index collection resources when collection created or destroyed' do
+    user = users(:regular_user)
+    material = materials(:good_material).becomes(DummyMaterial)
+    with_settings(solr_enabled: true) do
+      collection = user.collections.create!(title: 'test 123', materials: [material])
+
+      assert collection
+      assert_includes DummyMaterial.index, collection
+      assert_equal 1, DummyMaterial.index.length
+
+      assert collection.destroy
+      assert_equal 0, DummyMaterial.index.length
+    end
+  end
+
+  test 'index collection resources when collection renamed' do
+    user = users(:regular_user)
+    material = materials(:good_material).becomes(DummyMaterial)
+    collection = user.collections.create!(title: 'test 123', materials: [material])
+    assert collection
+
+    with_settings(solr_enabled: true) do
+      assert_equal 0, DummyMaterial.index.length
+
+      collection.update!(title: 'Hello world')
+      assert_includes DummyMaterial.index, collection
+      assert_equal 1, DummyMaterial.index.length
+    end
+  end
+
+  test 'do not index collection resources when collection updated without renaming' do
+    user = users(:regular_user)
+    material = materials(:good_material).becomes(DummyMaterial)
+    collection = user.collections.create!(title: 'test 123', materials: [material])
+    assert collection
+
+    with_settings(solr_enabled: true) do
+      assert_equal 0, DummyMaterial.index.length
+
+      collection.update!(description: 'hello')
+      assert_equal 0, DummyMaterial.index.length
     end
   end
 end


### PR DESCRIPTION
**Summary of changes**

- Make sure private method is not called when reindexing collection items on a collection.
- Add tests for reindexing
- Do reindexing in `after_commit`

**Motivation and context**
#841 
 
**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
