### PR TITLE
No "raw"

### DIFF
--- a/app/views/about/_elixir_widget_example.erb
+++ b/app/views/about/_elixir_widget_example.erb
@@ -15,7 +15,7 @@
                       apiKey: <%= Rails.application.secrets.google_maps_api_key %> // Get your own API key!
                   },
                   params: {
-                      country: [<%== raw t 'developer.gmaps_countries' %>],
+                      country: [<%== t 'developer.gmaps_countries' %>],
                       pageSize: 500
                   }
               });

--- a/app/views/about/developers.erb
+++ b/app/views/about/developers.erb
@@ -8,7 +8,7 @@
       <h2>For Developers</h2>
 
       <!-- ABOUT TESS DATA -->
-      <p><%== raw t 'developer.license' %></p>
+      <p><%== t 'developer.license' %></p>
 
       <div class="row" id="code_and_data">
         <div class="col-md-6 text-center">
@@ -25,7 +25,7 @@
           <div class="motivation-box">
             <i class="fa fa-code about-icon motivation-box-graphic-small"></i>
             <p>
-              Source code is available under the <%== raw t 'developer.code_license' %> license.
+              Source code is available under the <%== t 'developer.code_license' %> license.
             </p>
           </div>
         </div>
@@ -41,7 +41,7 @@
           <div class="motivation-box">
             <i class="fa fa-database about-icon motivation-box-graphic-small"></i>
             <p>
-              Data are made available under the <%== raw t 'developer.data_license' %> license.
+              Data are made available under the <%== t 'developer.data_license' %> license.
             </p>
           </div>
         </div>
@@ -50,7 +50,7 @@
       <!-- Widgets -->
       <div id="widgets" class="even-about-block">
         <h3>Widgets</h3>
-        <p><%== raw t 'developer.widgets' %></p>
+        <p><%== t 'developer.widgets' %></p>
         <p><%= link_to t('developer.widgets_available'), class: 'btn btn-primary', target: '_blank', rel: 'noopener' do %>
             View Our Available Widgets
           <% end %></p>
@@ -72,32 +72,32 @@
           <!-- Events -->
           <% if TeSS::Config.feature['events'] %>
             <code>
-              <a href="<%= TeSS::Config.base_url %><%== raw t 'developer.api_example_1' %>">
-                <%= TeSS::Config.base_url %><%== raw t 'developer.api_example_1' %></a>
+              <a href="<%= TeSS::Config.base_url %><%== t 'developer.api_example_1' %>">
+                <%= TeSS::Config.base_url %><%== t 'developer.api_example_1' %></a>
             </code><br/>
           <% end %>
 
           <!-- Materials -->
           <% if TeSS::Config.feature['materials'] %>
             <code>
-              <a href="<%= TeSS::Config.base_url %><%== raw t 'developer.api_example_3' %>">
-                <%= TeSS::Config.base_url %><%== raw t 'developer.api_example_3' %> </a>
+              <a href="<%= TeSS::Config.base_url %><%== t 'developer.api_example_3' %>">
+                <%= TeSS::Config.base_url %><%== t 'developer.api_example_3' %> </a>
             </code><br/>
           <% end %>
 
           <!-- Providers -->
           <% if TeSS::Config.feature['content_providers'] %>
             <code>
-              <a href="<%= TeSS::Config.base_url %><%== raw t 'developer.api_example_4' %>">
-                <%= TeSS::Config.base_url %><%== raw t 'developer.api_example_4' %> </a>
+              <a href="<%= TeSS::Config.base_url %><%== t 'developer.api_example_4' %>">
+                <%= TeSS::Config.base_url %><%== t 'developer.api_example_4' %> </a>
             </code><br/>
           <% end %>
 
           <!-- Workflows -->
           <% if TeSS::Config.feature['workflows'] %>
             <code>
-              <a href="<%= TeSS::Config.base_url %><%== raw t 'developer.api_example_5' %>">
-                <%= TeSS::Config.base_url %><%== raw t 'developer.api_example_5' %> </a>
+              <a href="<%= TeSS::Config.base_url %><%== t 'developer.api_example_5' %>">
+                <%= TeSS::Config.base_url %><%== t 'developer.api_example_5' %> </a>
             </code>
           <% end %>
         </p>

--- a/app/views/about/registering.html.erb
+++ b/app/views/about/registering.html.erb
@@ -7,9 +7,9 @@
     <div class="about-block">
       <!-- REGISTERING CONTENT IN TESS -->
       <div id="how">
-        <h2> <%== raw t('register.registering_resources_in', site_name: TeSS::Config.site['title_short']) %></h2>
+        <h2><%== t('register.registering_resources_in', site_name: TeSS::Config.site['title_short']) %></h2>
 
-        <p><%= raw t 'register.resources' %></p>
+        <p><%== t 'register.resources' %></p>
 
         <div class="row">
           <div class="col-lg-4 motivation-box">
@@ -33,42 +33,42 @@
           </div>
         </div>
 
-        <%== raw t 'register.methods' %>
+        <%== t 'register.methods' %>
       </div>
 
       <!-- AUTOMATIC REGISTRATION -->
       <div id="automatic" class="odd-about-block">
         <h3>Automatic Registration</h3>
-        <p><%== raw t 'register.automatic' %></p>
+        <p><%== t 'register.automatic' %></p>
 
         <!-- STRUCTURED DATA -->
         <h4>Structured Data Types</h4>
-        <%== raw t 'register.structured' %>
+        <%== t 'register.structured' %>
 
         <!-- BIOSCHEMAS -->
         <div id="bioschemas" class="sub-about-block">
           <h5>Schema.org / Bioschemas</h5>
           <%= image_tag 'about/bioschemas.png', class: 'structured-data-graphic' %>
-          <%== raw t 'register.schema' %>
+          <%== t 'register.schema' %>
         </div>
 
         <div id="sitemaps" class="sub-about-block">
           <h5>Sitemaps</h5>
-          <%== raw t 'register.sitemap' %>
+          <%== t 'register.sitemap' %>
         </div>
 
         <!-- API -->
         <div id="api" class="sub-about-block">
           <h5>API</h5>
           <i class="fa fa-plug about-icon structured-data-graphic"></i>
-          <%== raw t 'register.api' %>
+          <%== t 'register.api' %>
         </div>
 
         <!-- CALENDAR -->
         <div id="calendar" class="sub-about-block">
           <h5>Calendar</h5>
           <i class="fa fa-calendar about-icon structured-data-graphic"></i>
-          <%== raw t 'register.calendar' %>
+          <%== t 'register.calendar' %>
         </div>
 
         <!--  CONTACT US -->
@@ -76,7 +76,7 @@
           <%#= render :partial => "common/contact_form"%>
           <% if user_creatable_ingestion_methods.any? %>
             <h4>Sources</h4>
-            <%== raw t('register.user_managed_sources') %>
+            <%== t('register.user_managed_sources') %>
 
             <%= link_to new_content_provider_path, class: 'btn btn-primary', target: '_blank' do %>
               <i class="fa fa-plus-square"></i> Register provider
@@ -92,13 +92,13 @@
             for other methods...
           <% end %>
           <h4>Contact Us</h4>
-          <p><%== raw t('register.advice', contact_email: TeSS::Config.contact_email) %></p>
+          <p><%== t('register.advice', contact_email: TeSS::Config.contact_email) %></p>
         </div>
       </div>
 
       <div id="manual" class="even-about-block">
         <h3>Manual Registration</h3>
-        <p><%== raw t 'register.manual' %></p>
+        <p><%== t 'register.manual' %></p>
         <p>
           <%= link_to new_event_path, class: 'btn btn-primary', target: '_blank' do %>
             <i class="fa fa-plus-square"></i> Register event

--- a/app/views/about/tess.html.erb
+++ b/app/views/about/tess.html.erb
@@ -6,9 +6,9 @@
   <div id="content">
     <div class="about-block">
       <h2><%== TeSS::Config.site['title'] %></h2>
-      <p><%== raw t 'about.registry' %></p>
+      <p><%== t 'about.registry' %></p>
 
-      <p><%== raw t 'about.history' %></p>
+      <p><%== t 'about.history' %></p>
 
       <% @feature_count = 0 %>
 
@@ -20,14 +20,14 @@
             <%= image_tag('modern/icons/events-icon.svg', height: '65px', alt: 'Events') %>
           </div>
           <div class="col-lg-10 col-lg-pull-2 about-resource">
-            <p><%== raw t 'about.events' %></p>
+            <p><%== t 'about.events' %></p>
 
-            <p><%== raw t('about.collect_events', site_name: TeSS::Config.site['title_short'], count: Event.distinct.count(:content_provider_id), nominatim: t('about.nominatim'))  %></p>
+            <p><%== t('about.collect_events', site_name: TeSS::Config.site['title_short'], count: Event.distinct.count(:content_provider_id), nominatim: t('about.nominatim'))  %></p>
 
             <br/>
 
             <%= link_to events_path do %>
-              <%== raw t 'about.discover_events' %> <i class="icon icon-sm arrow-right-icon"></i>
+              <%== t 'about.discover_events' %> <i class="icon icon-sm arrow-right-icon"></i>
             <% end %>
           </div>
         </div>
@@ -43,15 +43,15 @@
           </div>
 
           <div class="col-lg-10 col-lg-pull-2 about-resource">
-            <p><%== raw t 'about.materials' %></p>
+            <p><%== t 'about.materials' %></p>
 
-            <p><%= raw t('about.collect_materials', site_name: TeSS::Config.site['title_short'], count: Material.distinct.count(:content_provider_id)) %>
+            <p><%== t('about.collect_materials', site_name: TeSS::Config.site['title_short'], count: Material.distinct.count(:content_provider_id)) %>
             </p>
 
             <br/>
 
             <%= link_to materials_path do %>
-              <%== raw t 'about.discover_materials' %> <i class="icon icon-sm arrow-right-icon"></i>
+              <%== t 'about.discover_materials' %> <i class="icon icon-sm arrow-right-icon"></i>
             <% end %>
           </div>
         </div>
@@ -69,19 +69,19 @@
           </div>
 
           <div class="col-lg-10 col-lg-pull-2 about-resource">
-            <p><%== raw t 'about.workflows' %></p>
+            <p><%== t 'about.workflows' %></p>
           </div>
 
           <div class="col-lg-12">
             <!-- INDIVIDUAL WORKFLOW TYPES-->
             <div class="sub-about-block">
               <h4>Learning Paths</h4>
-              <p><%== raw t 'about.learning_paths' %></p>
+              <p><%== t 'about.learning_paths' %></p>
             </div>
 
             <div class="sub-about-block">
               <h4>Educational Resource</h4>
-              <p><%== raw t 'about.resources' %></p>
+              <p><%== t 'about.resources' %></p>
             </div>
 
             <br/>
@@ -97,8 +97,8 @@
       <% if TeSS::Config.feature['subscription'] %>
         <div id="subscribe" class="<%= next_about_block(@feature_count += 1) %>">
           <h3>Subscribe</h3>
-          <p><%== raw t 'about.subscribe' %></p>
-          <p> raw t('about.subscription_manager', subscriptions_path: subscriptions_path)</p>
+          <p><%== t 'about.subscribe' %></p>
+          <p><%== t('about.subscription_manager', subscriptions_path: subscriptions_path) %></p>
           <%= image_tag 'about/subscription.png', style: 'width: 80%' %>
         </div>
       <% end %>
@@ -106,7 +106,7 @@
       <!-- WIDGET & API -->
       <div id="widget" class="<%= next_about_block(@feature_count += 1) %>">
         <h3>Widgets & API</h3>
-        <p><%== raw t 'about.widgets_and_api' %></p>
+        <p><%== t 'about.widgets_and_api' %></p>
         <%= link_to 'Learn more about Widgets', developers_path(anchor: 'widgets'), class: 'btn btn-default' %>
         <%= link_to 'Learn more about our API', developers_path(anchor: 'api'), class: 'btn btn-default' %>
       </div>

--- a/app/views/about/us.html.erb
+++ b/app/views/about/us.html.erb
@@ -11,19 +11,19 @@
       <!-- TeSS Club-->
       <div id="tess-club" class="<%= next_about_block(@feature_count += 1) %>">
         <h3>TeSS Club</h3>
-        <%== raw t 'us.tess_club' %>
+        <%== t 'us.tess_club' %>
       </div>
 
       <!-- CONTACT-->
       <div id="contact" class="<%= next_about_block(@feature_count += 1) %>">
         <h3>Contact</h3>
-        <%== raw t 'us.contact' %>
+        <%== t 'us.contact' %>
       </div>
 
       <!-- FUNDING-->
       <div id="funding" class="<%= next_about_block(@feature_count += 1) %>">
         <h3>Funding</h3>
-        <%== raw t 'us.funding' %>
+        <%== t 'us.funding' %>
         <% if TeSS::Config.funders.present? %>
           <p>
             <% TeSS::Config.funders.each do |funder| %>
@@ -38,20 +38,20 @@
       <!-- THE TEAM-->
       <div id="team" class="<%= next_about_block(@feature_count += 1) %>">
         <h3>The Team</h3>
-        <%== raw t 'us.team' %>
+        <%== t 'us.team' %>
       </div>
 
       <!-- ACKNOWLEDGEMENTS-->
       <div id="acknowledgements" class="<%= next_about_block(@feature_count += 1) %>">
         <h3>Acknowledgements</h3>
-        <%== raw t 'us.acknowledge' %>
+        <%== t 'us.acknowledge' %>
       </div>
 
       <!-- Cite -->
       <div id="cite" class="<%= next_about_block(@feature_count += 1) %>">
         <h3>Cite Us</h3>
         <blockquote>
-          <%== raw t 'us.cite' %>
+          <%== t 'us.cite' %>
         </blockquote>
       </div>
     </div>

--- a/app/views/common/_default_og.html.erb
+++ b/app/views/common/_default_og.html.erb
@@ -1,12 +1,12 @@
 <% # default twitter meta tags -%>
 <%= tag(:meta, name: "twitter:card",        content: 'summary_large_image') %>
-<%= tag(:meta, name: "twitter:site",        content: TeSS::Config.site['title_short']) %>
-<%= tag(:meta, name: "twitter:creator",     content: TeSS::Config.twitter_handle) %>
-<%= tag(:meta, name: "twitter:image",       content: asset_url(TeSS::Config.site['logo']) ) %>
+<%= tag(:meta, name: "twitter:site",        content: TeSS::Config.twitter_handle) unless TeSS::Config.twitter_handle.blank? %>
+<%= tag(:meta, name: "twitter:image",       content: asset_url(TeSS::Config.site['logo'])) %>
 <%= tag(:meta, name: "twitter:title",       content: TeSS::Config.site['title']) %>
-<%= tag(:meta, name: "twitter:description", content: t('home.subtitle') ) %>
+<%= tag(:meta, name: "twitter:description", content: strip_tags(t('home.subtitle'))) %>
+
 <% # default OpenGraph meta tags -%>
 <%= tag(:meta, property: "og:url",          content: request.original_url) %>
-<%= tag(:meta, property: "og:image",        content: asset_url(TeSS::Config.site['logo_open_graph']) ) %>
+<%= tag(:meta, property: "og:image",        content: asset_url(TeSS::Config.site['logo_open_graph'])) %>
 <%= tag(:meta, property: "og:title",        content: TeSS::Config.site['title']) %>
-<%= tag(:meta, property: "og:description",  content: t('home.subtitle') ) %>
+<%= tag(:meta, property: "og:description",  content: strip_tags(t('home.subtitle'))) %>

--- a/app/views/events/index.rss.erb
+++ b/app/views/events/index.rss.erb
@@ -1,1 +1,1 @@
-<%= raw rss_from_collection(@index_resources) %>
+<%== rss_from_collection(@index_resources) %>

--- a/app/views/events/partials/_address_finder.html.erb
+++ b/app/views/events/partials/_address_finder.html.erb
@@ -3,7 +3,7 @@
   <% if Rails.application.secrets.google_maps_api_key.present? &&
         !TeSS::Config.feature['disabled'].include?('address_finder') %>
     <input id="map-search" class="map-control form-control" type="text" placeholder="Start typing an address..."
-           title="<%== raw t 'events.hints.address' %>">
+           title="<%== t 'events.hints.address' %>">
     <%= content_tag(:div, id: 'google-map-form', data: {
         'map-latitude': f.object.latitude || TeSS::Config.gmaps['center']['latitude'],
         'map-longitude': f.object.longitude || TeSS::Config.gmaps['center']['longitude'],

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -28,7 +28,7 @@
   <% if @bioschemas.present? %>
     <% @bioschemas.each do |data| %>
       <script type="application/ld+json">
-        <%= raw data.to_json %>
+        <%== data.to_json %>
       </script>
     <% end %>
   <% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,7 +3,7 @@
   <nav class="header-notice">
     <div class="container">
       <div class="text-center">
-        <%= raw TeSS::Config.header_notice %>
+        <%== TeSS::Config.header_notice %>
       </div>
     </div>
   </nav>
@@ -85,7 +85,7 @@
     <div class="container">
       <div class="alert alert-info fade in" id="front-page-announcement">
         <button class="close" data-dismiss="alert" aria-label="close">&times;</button>
-        <%= raw TeSS::Config.announcement_message %>
+        <%== TeSS::Config.announcement_message %>
       </div>
     </div>
   <% end %>

--- a/app/views/static/error.html.erb
+++ b/app/views/static/error.html.erb
@@ -1,3 +1,3 @@
 <div id="error-message" class="alert alert-danger mt-5">
-  <%= raw @message %>
+  <%== @message %>
 </div>

--- a/app/views/static/home.html.erb
+++ b/app/views/static/home.html.erb
@@ -25,8 +25,8 @@
 <section>
   <%# Welcome text %>
   <div class="welcome-text">
-    <h1 class="module-heading"><%== raw t 'home.welcome' %></h1>
-    <p class="font-size-lg"><%== raw t 'home.subtitle' %></p>
+    <h1 class="module-heading"><%== t 'home.welcome' %></h1>
+    <p class="font-size-lg"><%== t 'home.subtitle' %></p>
   </div>
 
   <%# Big search box %>

--- a/app/views/static/home/_catalogue_blocks.html.erb
+++ b/app/views/static/home/_catalogue_blocks.html.erb
@@ -12,7 +12,7 @@
             <h3><%= feature.titleize %></h3>
           </div>
 
-          <div class="resource-type-text"><%== raw t "home.catalogue.#{feature}" %></div>
+          <div class="resource-type-text"><%== t "home.catalogue.#{feature}" %></div>
 
           <div class="resource-type-link">
               <span class="pseudolink">

--- a/app/views/static/home/_faq.html.erb
+++ b/app/views/static/home/_faq.html.erb
@@ -1,5 +1,5 @@
 <section id="faq">
-  <h2 class="text-center"><%= raw t 'home.faq.title' %></h2>
+  <h2 class="text-center"><%= t('home.faq.title') %></h2>
   <dl class="faq">
     <% TeSS::Config.site.dig('home_page', 'faq').each do |key| %>
       <div class="question">
@@ -7,7 +7,7 @@
           <h3><div class="expand">+</div><%= t("home.faq.#{key}.q") %></h3>
         </dt>
         <dd style="display: none;">
-          <%== raw t("home.faq.#{key}.a") %>
+          <%== t("home.faq.#{key}.a") %>
         </dd>
       </div>
     <% end %>

--- a/app/views/static/home/_promo_blocks.html.erb
+++ b/app/views/static/home/_promo_blocks.html.erb
@@ -1,22 +1,22 @@
 <ul class="promo-blocks" id="promo-blocks">
   <li>
     <%= image_tag(asset_path("modern/icons/nonprofit-icon.svg")) %>
-    <h4 class="text-primary"><%== raw t 'home.promo.nonprofit.title' %></h4>
-    <p><%== raw t 'home.promo.nonprofit.description' %></p>
+    <h4 class="text-primary"><%== t 'home.promo.nonprofit.title' %></h4>
+    <p><%== t 'home.promo.nonprofit.description' %></p>
   </li>
   <li>
     <%= image_tag(asset_path("modern/icons/community-icon.svg")) %>
-    <h4 class="text-primary"><%== raw t 'home.promo.community.title' %></h4>
-    <p><%== raw t 'home.promo.community.description' %></p>
+    <h4 class="text-primary"><%== t 'home.promo.community.title' %></h4>
+    <p><%== t 'home.promo.community.description' %></p>
   </li>
   <li>
     <%= image_tag(asset_path("modern/icons/sustainable-icon.svg")) %>
-    <h4 class="text-primary"><%== raw t 'home.promo.sustainable.title' %></h4>
-    <p><%== raw t 'home.promo.sustainable.description' %></p>
+    <h4 class="text-primary"><%== t 'home.promo.sustainable.title' %></h4>
+    <p><%== t 'home.promo.sustainable.description' %></p>
   </li>
   <li>
     <%= image_tag(asset_path("modern/icons/microscope-icon.svg")) %>
-    <h4 class="text-primary"><%== raw t 'home.promo.domain.title' %></h4>
-    <p><%== raw t 'home.promo.domain.description' %></p>
+    <h4 class="text-primary"><%== t 'home.promo.domain.title' %></h4>
+    <p><%== t 'home.promo.domain.description' %></p>
   </li>
 </ul>

--- a/app/views/static/home/_provider_carousel.html.erb
+++ b/app/views/static/home/_provider_carousel.html.erb
@@ -10,7 +10,7 @@
   <% providers = ContentProvider.where(id: provider_ids) %>
   <% return if providers.none? %>
   <section id="providers">
-    <h2 class="text-center"><%= raw t 'home.providers.title' %></h2>
+    <h2 class="text-center"><%= t('home.providers.title') %></h2>
     <div class="carousel slide multi-item-carousel" id="providers-carousel">
       <div class="carousel-inner">
         <%
@@ -33,7 +33,7 @@
     </div>
 
     <div class="text-center font-size-lg">
-      <%== raw t 'home.providers.content' %>
+      <%== t 'home.providers.content' %>
       <p>
         <%= link_to t('home.providers.button_text'), registering_resources_path, class: 'btn btn-primary' %>
       </p>

--- a/app/views/static/privacy.html.erb
+++ b/app/views/static/privacy.html.erb
@@ -4,40 +4,40 @@
   <h3>Information Submitted</h3>
 
   <h4>Registration</h4>
-  <%== raw t 'privacy.registration' %>
+  <%== t 'privacy.registration' %>
 
   <h4>Additional Personal Information</h4>
-  <p><%== raw t 'privacy.personal' %></p>
+  <p><%== t 'privacy.personal' %></p>
 
   <h4>Creation of <%= TeSS::Config.site['title_short'] %> Resources</h4>
-  <p><%== raw t 'privacy.resources' %></p>
+  <p><%== t 'privacy.resources' %></p>
 
   <h3>Information Automatically Collected</h3>
 
   <h4>Server Logs</h4>
-  <p><%== raw t 'privacy.server' %></p>
+  <p><%== t 'privacy.server' %></p>
 
   <h4>Cookies</h4>
-  <p><%== raw t 'privacy.cookies' %></p>
+  <p><%== t 'privacy.cookies' %></p>
 
   <% if TeSS::Config.analytics_enabled %>
     <h4>Analytics</h4>
-    <p><%== raw t 'privacy.analytics' %></p>
+    <p><%== t 'privacy.analytics' %></p>
   <% end %>
 
   <h3>Information Retention</h3>
-  <p><%== raw t 'privacy.retention' %></p>
+  <p><%== t 'privacy.retention' %></p>
 
   <h3>Code of Conduct</h3>
-  <p><%== raw t 'privacy.code' %></p>
+  <p><%== t 'privacy.code' %></p>
 
   <h3>Data Controller</h3>
-  <p><%== raw t 'privacy.controller' %></p>
+  <p><%== t 'privacy.controller' %></p>
   <em>For any enquiries or requests, please contact:</em><br/>
   <strong>Email:</strong> <%= mail_to(TeSS::Config.contact_email, TeSS::Config.contact_email) -%><br/>
   <% if !t('privacy.post').blank? %>
     <strong>Post:</strong>
 
-    <address><%== raw t 'privacy.post' %></address>
+    <address><%== t 'privacy.post' %></address>
   <% end %>
 </div>

--- a/config/tess.example.yml
+++ b/config/tess.example.yml
@@ -2,7 +2,7 @@ default: &default
   base_url: http://localhost:3000
   contact_email: contact@example.com
   sender_email: no-reply@localhost
-  twitter_handle: '@handle'
+  twitter_handle: # @handle
   solr_enabled: true
   solr_facets:
     # see `searchable` block in app/model/*.rb for names


### PR DESCRIPTION
**Summary of changes**

- Replaces uses of `raw` with `==` when permitting HTML in strings.
- Improves some Twitter-related meta tags.

**Motivation and context**

- `raw`/`==` was being used inconsistently, and sometimes redundantly.
- Twitter handle was being set by default (to `@handle`).
- The wrong meta tag was used to tag the site's own Twitter handle.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
