### PR TITLE
Make sure unapproved sources are skipped

### DIFF
--- a/lib/scraper.rb
+++ b/lib/scraper.rb
@@ -69,7 +69,7 @@ class Scraper
 
       data_sources = {
         config: @sources.map { |c| Scraper::ConfigSource.new(c.merge(user: user)) },
-        database: Source.find_each
+        database: Source.approved.find_each
       }
 
       data_sources.each do |key, sources|
@@ -81,9 +81,9 @@ class Scraper
           processed += 1
           log '', 1
           if source.enabled
-            log t('scraper.messages.processing', source: source.provider, num: processed.to_s), 1
+            log t('scraper.messages.processing', source: source.content_provider&.title, num: processed.to_s), 1
           else
-            log t('scraper.messages.skipped', source: source.provider, num: processed.to_s), 1
+            log t('scraper.messages.skipped', source: source.content_provider&.title, num: processed.to_s), 1
             next
           end
           if validate_source(source)

--- a/test/config/test_ingestion_disabled.yml
+++ b/test/config/test_ingestion_disabled.yml
@@ -1,0 +1,15 @@
+name: test disabled
+logfile: log/ingestion.test.log
+loglevel: 0
+username: ingestor
+sources:
+  - id: 1
+    provider: 'Another Portal Provider'
+    url: 'https://app.com/events/sitemap.xml'
+    method: ical
+    enabled: true
+  - id: 2
+    provider: 'Another Portal Provider'
+    url: 'https://app.com/events/disabled.xml'
+    method: ical
+    enabled: false

--- a/test/fixtures/sources.yml
+++ b/test/fixtures/sources.yml
@@ -94,3 +94,11 @@ enabled_source:
   enabled: true
   user: regular_user
   approval_status: 2
+
+disabled_source:
+  content_provider: portal_provider
+  url: 'https://website.org'
+  method: bioschemas
+  enabled: false
+  user: regular_user
+  approval_status: 2


### PR DESCRIPTION
**Summary of changes**

- Builds upon previous PR to also skip unapproved sources when scraping.
- Also fixes logging issue when scraping sources from database.

**Motivation and context**

It was discovered that disabled/unapproved sources were still being scraped.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
