### PR TITLE
Strip leading/trailing whitespace from attributes

### DIFF
--- a/app/models/autocomplete_suggestion.rb
+++ b/app/models/autocomplete_suggestion.rb
@@ -1,5 +1,6 @@
 class AutocompleteSuggestion < ApplicationRecord
   def self.add(field, *suggestions)
+    suggestions = clean(suggestions)
     upsert_all(suggestions.map { |s| { field: field, value: s } }, unique_by: [:field, :value]) if suggestions.any?
   end
 
@@ -18,10 +19,15 @@ class AutocompleteSuggestion < ApplicationRecord
   end
 
   def self.refresh(field, *suggestions)
+    suggestions = clean(suggestions)
     add(field, *suggestions)
     redundant = where(field: field).where.not(value: suggestions)
     count = redundant.count
     redundant.destroy_all if count > 0
     count
+  end
+
+  def self.clean(suggestions)
+    suggestions.map(&:strip)
   end
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -15,7 +15,7 @@ class Collection < ApplicationRecord
 
   # Remove trailing and squeezes (:squish option) white spaces inside the string (before_validation):
   # e.g. "James     Bond  " => "James Bond"
-  auto_strip_attributes :title, :description, :image_url, :squish => false
+  auto_strip_attributes :title, :description, :image_url, squish: false
 
   after_commit :index_items, if: :title_previously_changed?
 

--- a/app/models/content_provider.rb
+++ b/app/models/content_provider.rb
@@ -29,7 +29,7 @@ class ContentProvider < ApplicationRecord
 
   # Remove trailing and squeezes (:squish option) white spaces inside the string (before_validation):
   # e.g. "James     Bond  " => "James Bond"
-  auto_strip_attributes :title, :description, :url, :image_url, :squish => false
+  auto_strip_attributes :title, :description, :url, :image_url, squish: false
 
   validates :title, :url, presence: true
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -109,6 +109,8 @@ class Event < ApplicationRecord
 
   has_many :stars,  as: :resource, dependent: :destroy
 
+  auto_strip_attributes :title, :description, :url, squish: false
+
   validates :title, :url, presence: true
   validates :url, url: true
   validates :capacity, numericality: { greater_than_or_equal_to: 1 }, allow_blank: true

--- a/app/models/material.rb
+++ b/app/models/material.rb
@@ -88,7 +88,7 @@ class Material < ApplicationRecord
   
   # Remove trailing and squeezes (:squish option) white spaces inside the string (before_validation):
   # e.g. "James     Bond  " => "James Bond"
-  auto_strip_attributes :title, :description, :url, :squish => false
+  auto_strip_attributes :title, :description, :url, squish: false
 
   validates :title, :description, :url, presence: true
   validates :url, url: true

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,6 +1,7 @@
 require 'uri'
 
 class Profile < ApplicationRecord
+  auto_strip_attributes :firstname, :surname, :website, :orcid, squish: false
   belongs_to :user, inverse_of: :profile
 
   before_validation :check_orcid

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,6 +68,8 @@ class User < ApplicationRecord
            :omniauthable, :authentication_keys => [:login]
   end
 
+  auto_strip_attributes :username, squish: false
+
   validates :username, presence: true, uniqueness: { case_sensitive: false }
 
   validate :consents_to_processing, on: :create, unless: ->(user) { user.using_omniauth? || User.current_user.try(:is_admin?) }

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -55,6 +55,8 @@ class Workflow < ApplicationRecord
 
   has_many :stars,  as: :resource, dependent: :destroy
 
+  auto_strip_attributes :title, squish: false
+
   validates :title, presence: true
 
   clean_array_fields(:keywords, :contributors, :authors, :target_audience)

--- a/lib/array_field_cleaner.rb
+++ b/lib/array_field_cleaner.rb
@@ -30,7 +30,7 @@ module ArrayFieldCleaner
         if self[field].nil?
           self[field] = []
         else
-          self[field] = self[field].reject{ |element| element.blank? }
+          self[field] = self[field].reject{ |element| element.blank? }.map(&:strip)
         end
       end
     end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -236,8 +236,8 @@ class UsersControllerTest < ActionController::TestCase
     assert_equal false, profile_new.public
     assert_equal 'fake@email.com', profile_new.email
     assert_nil profile_new.image_url
-    assert_equal '', profile_new.orcid
-    assert_equal '', profile_new.website
+    assert_nil profile_new.orcid
+    assert_nil profile_new.website
     assert_equal 3, profile_new.expertise_technical.size, 'expertise_technical array size not matchted.'
   end
 

--- a/test/models/collection_test.rb
+++ b/test/models/collection_test.rb
@@ -158,4 +158,12 @@ class CollectionTest < ActiveSupport::TestCase
       assert_equal 0, DummyMaterial.index.length
     end
   end
+
+  test 'should strip attributes' do
+    mock_images
+    collection = collections(:one)
+    assert collection.update(title: ' Collection  Title  ', image_url: " http://image.host/another_image.png\n")
+    assert_equal 'Collection  Title', collection.title
+    assert_equal 'http://image.host/another_image.png', collection.image_url
+  end
 end

--- a/test/models/content_provider_test.rb
+++ b/test/models/content_provider_test.rb
@@ -65,4 +65,15 @@ class ContentProviderTest < ActiveSupport::TestCase
     assert content_provider.valid?
   end
 
+  test 'should strip attributes' do
+    mock_images
+    WebMock.stub_request(:any, 'http://website.com').to_return(status: 200, body: 'hi')
+    content_provider = content_providers(:goblet)
+    assert content_provider.update(title: ' Provider  Title  ',
+                                   url: "\t  \t  http://website.com ",
+                                   image_url: " http://image.host/another_image.png\n")
+    assert_equal 'Provider  Title', content_provider.title
+    assert_equal 'http://website.com', content_provider.url
+    assert_equal 'http://image.host/another_image.png', content_provider.image_url
+  end
 end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -537,4 +537,10 @@ class EventTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test 'should strip attributes' do
+    assert @event.update(title: ' Event  Title  ', url: " https://event.com\n")
+    assert_equal 'Event  Title', @event.title
+    assert_equal 'https://event.com', @event.url
+  end
 end

--- a/test/models/material_test.rb
+++ b/test/models/material_test.rb
@@ -152,8 +152,8 @@ class MaterialTest < ActiveSupport::TestCase
     assert_equal [], @material.authors
   end
 
-  test 'should strip bad values from authors array input' do
-    authors = ['john', 'bob', nil, [], '', 'frank']
+  test 'should remove bad values and strip authors array input' do
+    authors = ['john', 'bob', nil, [], '', 'frank ']
     expected_authors = ['john', 'bob', 'frank']
     assert @material.update(authors: authors)
     assert_equal expected_authors, @material.authors
@@ -535,4 +535,9 @@ class MaterialTest < ActiveSupport::TestCase
     end
   end
 
+  test 'should strip attributes' do
+    assert @material.update(title: ' Material  Title  ', url: " https://material.com\n")
+    assert_equal 'Material  Title', @material.title
+    assert_equal 'https://material.com', @material.url
+  end
 end

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -1,10 +1,22 @@
 require 'test_helper'
 
 class ProfileTest < ActiveSupport::TestCase
-
   test 'full name' do
     assert_equal 'Hannah Montana', Profile.new(firstname: 'Hannah', surname: 'Montana').full_name
     assert_equal 'Bob', Profile.new(firstname: 'Bob').full_name
   end
 
+  test 'should strip name and email' do
+    WebMock.stub_request(:any, 'http://website.com').to_return(status: 200, body: 'hi')
+    profile = users(:regular_user).profile
+    assert profile.update(firstname: ' Space ',
+                          surname: "\tSpaceson\r\n",
+                          website: ' http://website.com',
+                          orcid: '  https://orcid.org/0000-0002-1825-0097 ')
+
+    assert_equal 'Space', profile.firstname
+    assert_equal 'Spaceson', profile.surname
+    assert_equal 'http://website.com', profile.website
+    assert_equal 'https://orcid.org/0000-0002-1825-0097', profile.orcid
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -401,4 +401,11 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 'MixedCaseUsername', user.username
     assert_equal 'mixedcaseemail@example.com', user.email
   end
+
+  test 'should strip attributes' do
+    user = User.new(@user_params.merge(username: ' space ', email: ' new-user@example.com '))
+    assert user.save
+    assert_equal 'space', user.username
+    assert_equal 'new-user@example.com', user.email
+  end
 end

--- a/test/models/workflow_test.rb
+++ b/test/models/workflow_test.rb
@@ -104,4 +104,9 @@ class WorkflowTest < ActiveSupport::TestCase
     assert_equal 'something', workflow.difficulty_level
     assert workflow.errors.added?(:difficulty_level, 'must be a controlled vocabulary term')
   end
+
+  test 'should strip attributes' do
+    assert @wf1.update(title: ' Workflow  Title  ')
+    assert_equal 'Workflow  Title', @wf1.title
+  end
 end

--- a/test/unit/autocomplete_suggestion_test.rb
+++ b/test/unit/autocomplete_suggestion_test.rb
@@ -29,7 +29,7 @@ class AutocompleteSuggestionTest < ActiveSupport::TestCase
 
   test 'add' do
     assert_difference('AutocompleteSuggestion.count', 2) do
-      AutocompleteSuggestion.add('keywords', 'apple', 'banana', 'grape', 'pineapple')
+      AutocompleteSuggestion.add('keywords', 'apple', 'banana', 'grape', 'pineapple', 'banana ')
       assert AutocompleteSuggestion.where(field: 'keywords', value: 'apple').exists?
     end
 
@@ -59,7 +59,7 @@ class AutocompleteSuggestionTest < ActiveSupport::TestCase
     id = suggestion.id
 
     assert_difference('AutocompleteSuggestion.count', -3) do
-      AutocompleteSuggestion.refresh('keywords', 'apple', 'starfruit')
+      AutocompleteSuggestion.refresh('keywords', 'apple', 'starfruit', 'apple ')
     end
 
     assert_equal id, AutocompleteSuggestion.where(field: 'keywords', value: 'apple').first.id
@@ -81,7 +81,7 @@ class AutocompleteSuggestionTest < ActiveSupport::TestCase
     end
 
     assert_difference('AutocompleteSuggestion.count', 1) do
-      e.keywords = ['AppLE', 'banana', 'grape', 'pineapple']
+      e.keywords = ['AppLE', 'banana', 'grape', 'pineapple', 'banana ']
       e.save!
     end
 

--- a/test/unit/ingestors/wur_ingestor_test.rb
+++ b/test/unit/ingestors/wur_ingestor_test.rb
@@ -17,7 +17,7 @@ class WurIngestorTest < ActiveSupport::TestCase
     ingestor = Ingestors::WurIngestor.new
 
     # check event doesn't
-    new_title = ' Genetic Diversity - key to transitions in agriculture and forestry '
+    new_title = 'Genetic Diversity - key to transitions in agriculture and forestry'
     new_url = 'https://www.wur.nl/en/activity/genetic-diversity-key-to-transitions-in-agriculture-and-forestry-1.htm'
     refute Event.where(title: new_title, url: new_url).any?
 


### PR DESCRIPTION
**Summary of changes**

- Updates `array_field_cleaner` to also strip strings.
- Adds `auto_strip_attributes` to various models that didn't have it before.
- Strip autocomplete suggestions.

**Motivation and context**

Noticed a seemingly duplicate keyword suggestion on the dev server (`AAI` and `AAI `).
 
**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
