### PR TITLE
Expire carousel if content provider changes image

### DIFF
--- a/app/views/static/home/_provider_carousel.html.erb
+++ b/app/views/static/home/_provider_carousel.html.erb
@@ -5,10 +5,10 @@
   where.not(image_file_size: nil).
   last(TeSS::Config.site['n_provider_ids']).pluck(:id) if provider_ids.nil? %>
 <% return if provider_ids.blank? %>
+<% providers = ContentProvider.where(id: provider_ids) %>
+<% return if providers.none? %>
 
-<% cache(['home', 'provider-carousel', provider_ids.join('-')]) do %>
-  <% providers = ContentProvider.where(id: provider_ids) %>
-  <% return if providers.none? %>
+<% cache(['home', 'provider-carousel', providers]) do %>
   <section id="providers">
     <h2 class="text-center"><%= t('home.providers.title') %></h2>
     <div class="carousel slide multi-item-carousel" id="providers-carousel">


### PR DESCRIPTION
**Summary of changes**

- Changes carousel cache key to be based on latest `updated_at` of displayed providers.

**Motivation and context**

A provider updated their logo and TeSS was displaying a broken image in the carousel.
 
**Screenshots**

![image](https://github.com/ElixirTeSS/TeSS/assets/503373/efac957b-7ad4-4db6-82a4-5bc5863f3493)

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
