### PR TITLE
Include new users in autocompletes. Fixes #867

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -87,7 +87,7 @@ class User < ApplicationRecord
 
   scope :accepteds, -> { invited.where.not(invitation_accepted_at: nil) }
 
-  scope :visible, -> { not_banned.non_default.verified.where(invitation_token: nil).or(accepteds) }
+  scope :visible, -> { not_banned.non_default.not_rejected.where(invitation_token: nil).or(accepteds) }
   # ---
 
   def self.find_for_database_authentication(warden_conditions)
@@ -305,6 +305,10 @@ class User < ApplicationRecord
 
   def self.verified
     where.not(role_id: [Role.rejected, Role.unverified])
+  end
+
+  def self.not_rejected
+    where.not(role_id: Role.rejected)
   end
 
   def unverified_or_rejected?

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -401,13 +401,13 @@ class UsersControllerTest < ActionController::TestCase
     refute assigns(:users).include?(users(:another_regular_user))
   end
 
-  test 'should not show banned or unverified/basic users in index' do
+  test 'should not show banned or basic users in index' do
     get :index
     assert_response :success
     all_users = assigns(:users).to_a
     assert users(:shadowbanned_user).banned?
     assert_not_includes all_users, users(:shadowbanned_user)
-    assert_not_includes all_users, users(:unverified_user)
+    assert_includes all_users, users(:unverified_user)
     assert_not_includes all_users, users(:basic_user)
     assert_includes all_users, users(:regular_user)
   end
@@ -470,5 +470,22 @@ class UsersControllerTest < ActionController::TestCase
 
     assert_select 'a[data-toggle="tab"]', text: "Events (#{user.events.count})"
     assert_select '#events a[href=?]', events_path(user: user.username, include_expired: true)
+  end
+
+  test 'should be able to filter for new user with a query' do
+    get :index, params: { q: 'unver' }
+
+    assert_response :success
+    assert assigns(:users).include?(users(:unverified_user))
+
+    get :index, params: { q: 'naugh' }
+
+    assert_response :success
+    refute assigns(:users).include?(users(:shadowbanned_unverified_user))
+
+    get :index, params: { q: 'basic' }
+
+    assert_response :success
+    refute assigns(:users).include?(users(:basic_user))
   end
 end


### PR DESCRIPTION
**Summary of changes**

- Ensures newly registered users are listed when autocompleting (e.g. when adding editors to a content provider)

**Motivation and context**

#867

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
