### PR TITLE
Hide archived materials

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -667,4 +667,9 @@ module ApplicationHelper
                          fail_date: resource.link_monitor.failed_at.strftime(EventsHelper::DATE_STRF)),
                 class: 'alert alert-warning mb-4 broken-link-notice')
   end
+
+  def archived_notice(resource)
+    content_tag('div', t('warnings.archived', resource_type: resource.model_name.human.downcase),
+                class: 'alert alert-warning mb-4 archived-notice')
+  end
 end

--- a/app/models/material.rb
+++ b/app/models/material.rb
@@ -69,6 +69,9 @@ class Material < ApplicationRecord
       string :collections, multiple: true do
         collections.where(public: true).pluck(:title)
       end
+      string :status do
+        MaterialStatusDictionary.instance.lookup_value(self.status, 'title')
+      end
     end
     # :nocov:
   end
@@ -116,7 +119,7 @@ class Material < ApplicationRecord
   def self.facet_fields
     field_list = %w(scientific_topics operations tools standard_database_or_policy content_provider keywords
                     difficulty_level fields licence target_audience authors contributors resource_type
-                    related_resources user node collections)
+                    related_resources user node collections status)
 
     field_list.delete('operations') if TeSS::Config.feature['disabled'].include? 'operations'
     field_list.delete('scientific_topics') if TeSS::Config.feature['disabled'].include? 'topics'
@@ -125,6 +128,7 @@ class Material < ApplicationRecord
     field_list.delete('fields') if TeSS::Config.feature['disabled'].include? 'ardc_fields_of_research'
     field_list.delete('node') unless TeSS::Config.feature['nodes']
     field_list.delete('collections') unless TeSS::Config.feature['collections']
+    field_list.delete('status') if TeSS::Config.feature['disabled'].include? 'status'
 
     field_list
   end
@@ -163,5 +167,9 @@ class Material < ApplicationRecord
     end
 
     c
+  end
+
+  def archived?
+    status == 'archived'
   end
 end

--- a/app/views/materials/show.html.erb
+++ b/app/views/materials/show.html.erb
@@ -9,6 +9,7 @@
     <div id="home">
       <div>
         <%= broken_link_notice(@material) if @material.failing? %>
+        <%= archived_notice(@material) if @material.archived? %>
 
         <!-- Field: title -->
         <div class="sub-heading"><%= display_attribute_no_label(@material, :resource_type) { |values| values.join(', ') } %></div>

--- a/app/views/search/common/_facet_sidebar.html.erb
+++ b/app/views/search/common/_facet_sidebar.html.erb
@@ -53,6 +53,11 @@ Variable that should be available
                                                                                 count: '-',
                                                                                 enable_text: 'Show past events',
                                                                                 disable_text: 'Hide past events' } %>
+  <% elsif resource_type.name == 'Material' %>
+    <%= render partial: 'search/common/facet_sidebar_boolean_filter', locals: { facet_field: 'include_archived',
+                                                                                count: '-',
+                                                                                enable_text: 'Show archived materials',
+                                                                                disable_text: 'Hide archived materials' } %>
   <% end %>
 </ul>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -543,6 +543,7 @@ en:
     404: "The requested page could not be found - you may have mistyped the address or the page may have moved (404 Not Found)."
   warnings:
     link_broken: TeSS has been unable to access this %{resource_type}'s URL since %{fail_date} - the page may have been moved.
+    archived: This %{resource_type} has been archived, its content may no longer be relevant.
   footer:
     eu_funding: >
       TeSS has received funding from the European Union’s Horizon 2020 research and innovation programme under grant agreement No. <a href="https://cordis.europa.eu/project/rcn/198519_en.html", target="_blank">676559</a>.

--- a/test/controllers/materials_controller_test.rb
+++ b/test/controllers/materials_controller_test.rb
@@ -362,6 +362,7 @@ class MaterialsControllerTest < ActionController::TestCase
       assert assigns(:material)
       assert_select 'fa-commenting-o', count: 0
       assert_select '.broken-link-notice', count: 0
+      assert_select '.archived-notice', count: 0
     end
   end
 
@@ -1383,5 +1384,15 @@ class MaterialsControllerTest < ActionController::TestCase
       assert_select "label", {:count=>1, :text=>"Keywords"}
       assert_select "label", {:count=>1, :text=>"Operations"}
     end
+  end
+
+  test 'should display archived warning' do
+    material = materials(:material_with_external_resource)
+    assert material.archived?
+
+    get :show, params: { id: material }
+
+    assert_response :success
+    assert_select '.archived-notice', text: /material has been archived/
   end
 end

--- a/test/models/material_test.rb
+++ b/test/models/material_test.rb
@@ -540,4 +540,11 @@ class MaterialTest < ActiveSupport::TestCase
     assert_equal 'Material  Title', @material.title
     assert_equal 'https://material.com', @material.url
   end
+
+  test 'archived?' do
+    assert materials(:material_with_external_resource).archived?
+    refute materials(:material_with_suggestions).archived?
+    refute materials(:bad_material).archived?
+    refute Material.new.archived?
+  end
 end


### PR DESCRIPTION
**Summary of changes**

- Add filter for material "status".
- Hide materials flagged as "Archived" from the default results.
- Add a toggle to show archived materials (as is done for past events).
- Display a warning notice when viewing an archived material.

**Motivation and context**

#870

Part of general curation activity to reduce amount of irrelevant content.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
