### PR TITLE
working start time filtering

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -38,6 +38,8 @@
 //= require turbolinks
 
 function updateURLParameter(url, param, paramVal){
+    // This can be done in a nicer way with URLSearchParams
+    // https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams
     var newAdditionalURL = "";
     var tempArray = url.split("?");
     var baseURL = tempArray[0];
@@ -53,7 +55,11 @@ function updateURLParameter(url, param, paramVal){
             }
         }
     }
-    var rowsTxt = temp + "" + param + "=" + paramVal;
+    if (paramVal) {
+        var rowsTxt = temp + "" + param + "=" + paramVal;
+    } else {
+        rowsTxt = "";
+    }
     return baseURL + "?" + newAdditionalURL + rowsTxt;
 }
 
@@ -63,6 +69,20 @@ function redirect_to_sort_url(){
             window.location.href,
             "sort",
             $("#sort").find(":selected").val()
+        )
+    );
+}
+
+function redirect_with_updated_search(param, paramVal) {
+    // special case for empty range types
+    if (param == 'start' && paramVal == '..') {
+        paramVal = undefined;
+    }
+    window.location.replace(
+        updateURLParameter(
+            window.location.href,
+            param,
+            paramVal
         )
     );
 }

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -32,11 +32,26 @@ module Searchable
         any do
           # Set all facets
           normal_facets.each do |facet_title, facet_value|
-            any do # Conjunction clause
-              # Add to array that get executed lower down
+            # Start date is a AND search parameter in my opinion.
+            if facet_title == 'start'
               active_facets[facet_title] ||= []
-              val = Facets.process(facet_title, facet_value)
-              active_facets[facet_title] << with(facet_title, val)
+              lb, ub = Facets.process(facet_title, facet_value)
+              # We should think about timezone handling here
+              if lb && ub
+                active_facets[facet_title] << with(facet_title).between(lb..ub)
+              elsif lb
+                active_facets[facet_title] << with(facet_title).greater_than_or_equal_to(lb)
+              elsif ub
+                active_facets[facet_title] << with(facet_title).less_than_or_equal_to(ub)
+              else
+              end
+            else
+              any do # Conjunction clause
+                # Add to array that get executed lower down
+                active_facets[facet_title] ||= []
+                val = Facets.process(facet_title, facet_value)
+                active_facets[facet_title] << with(facet_title, val)
+              end
             end
           end
         end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -58,9 +58,9 @@ class Event < ApplicationRecord
       end
       string :keywords, multiple: true
       string :fields, multiple: true
-      time :start
+      time :start, trie: true
       time :end
-      time :created_at
+      time :created_at, trie: true
       time :updated_at
       string :content_provider do
         content_provider.title unless content_provider.nil?
@@ -175,7 +175,7 @@ class Event < ApplicationRecord
 
   def self.facet_fields
     field_list = %w[ content_provider keywords scientific_topics operations tools fields online event_types
-                     venue city country organizer sponsors target_audience eligibility user node collections ]
+                     start venue city country organizer sponsors target_audience eligibility user node collections ]
 
     field_list.delete('operations') if TeSS::Config.feature['disabled'].include? 'operations'
     field_list.delete('scientific_topics') if TeSS::Config.feature['disabled'].include? 'topics'

--- a/app/views/search/common/_facet_sidebar.html.erb
+++ b/app/views/search/common/_facet_sidebar.html.erb
@@ -13,7 +13,7 @@ Variable that should be available
 
 <%
   extras = if resource_type.name == 'Event'
-             [['Most recent', 'new'], ['Earliest', 'early'], ['Latest', 'late']]
+             [['Earliest', 'early'], ['Latest', 'late'], ['Most recent', 'new']]
            elsif resource_type.name == 'Source'
              [['Most recent', 'new'], ['Last finished', 'finished']]
            else
@@ -34,14 +34,14 @@ Variable that should be available
     </h4>
   </li>
 
-  <% if TeSS::Config.facets_max_age_list.include?(resource_type.name) %>
-    <%= render partial: 'search/common/facet_sidebar_max_age' %>
-  <% end %>
-
   <% boolean_facets, regular_facets = available_facets(resources).partition { |f| f.field_name == :online } %>
 
   <% regular_facets.each do |facet| %>
-    <%= render partial: 'search/common/facet_sidebar_filter', locals: { facet: facet, resources: resources } %>
+    <% if facet.field_name == :start %>
+      <%= render partial: 'search/common/facet_sidebar_date_filter', locals: { facet: facet, resources: resources } %>
+    <% else %>
+      <%= render partial: 'search/common/facet_sidebar_filter', locals: { facet: facet, resources: resources } %>
+    <% end %>
   <% end %>
 
   <% boolean_facets.each do |facet| %>
@@ -58,6 +58,10 @@ Variable that should be available
                                                                                 count: '-',
                                                                                 enable_text: 'Show archived materials',
                                                                                 disable_text: 'Hide archived materials' } %>
+  <% end %>
+
+  <% if TeSS::Config.facets_max_age_list.include?(resource_type.name) %>
+    <%= render partial: 'search/common/facet_sidebar_max_age' %>
   <% end %>
 </ul>
 

--- a/app/views/search/common/_facet_sidebar_date_filter.html.erb
+++ b/app/views/search/common/_facet_sidebar_date_filter.html.erb
@@ -1,0 +1,19 @@
+<% facet_field = facet.field_name.to_s %>
+<% lb, ub = params[facet_field]&.split('..') %>
+<li class="sidebar-group mt-4">
+  <ul>
+    <li>
+      <div class="nav-heading filter-heading">
+        <span class="icon icon-lg events-icon"></span>
+        <span><%= t("facets.titles.#{facet_field}", default: facet_field.humanize.singularize) %></span>
+        <div class="pull-right filter-expand"><i class="icon icon-md expand-icon"></i></div>
+      </div>
+    </li>
+
+    <li class="nav-item active" style="display: none; font-size: 15px; text-align: center;">
+      <input type="date" name="<%= facet_field %>_lb" value="<%= lb %>" style="width: 47%;" onchange="redirect_with_updated_search('<%= facet_field %>', this.value + '..' + '<%= ub %>');">
+       - 
+      <input type="date" name="<%= facet_field %>_ub" value="<%= ub %>" style="width: 47%;" onchange="redirect_with_updated_search('<%= facet_field %>', '<%= lb %>' + '..' + this.value);">
+    </li>
+  </ul>
+</li>

--- a/lib/facets.rb
+++ b/lib/facets.rb
@@ -13,6 +13,7 @@ module Facets
       include_expired: -> (value) { value == 'true'},
       include_archived: -> (value) { value == 'true'},
       max_age: -> (value) { Subscription::FREQUENCY.detect { |f| f[:title] == value }.try(:[], :period) },
+      start: -> (value) { value.split('..').map {|d| Date.parse(d) } },
       include_hidden: -> (value) { value == 'true'}
   }
 


### PR DESCRIPTION
**Summary of changes**

- Add date filtering to events (start date only for now)
- Fix default sort order display for events (sort order was ok)

**Motivation and context**

We would like to find only events before/after a date or in a date range.
Additionally, this filtering will be very useful when implementing a calendar view.
 
**Screenshots**

![image](https://github.com/ElixirTeSS/TeSS/assets/35944/2c4092f8-14fb-4e41-a185-4a81c64fac5d)


**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
