### PR TITLE
use bootstrap-tab-history to pop tab switches onto history

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -115,6 +115,7 @@ gem 'icalendar', '~> 2.4.1'
 gem 'rss'
 
 gem 'bootstrap-datepicker-rails', '~> 1.6.4.1'
+gem 'bootstrap-tab-history-rails'
 
 gem 'rack-cors', require: 'rack/cors'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,6 +154,8 @@ GEM
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
+    bootstrap-tab-history-rails (0.1.0)
+      railties (>= 3.1)
     builder (3.2.4)
     byebug (11.1.3)
     case_transform (0.2)
@@ -785,6 +787,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   bootstrap-datepicker-rails (~> 1.6.4.1)
   bootstrap-sass (>= 3.4.1)
+  bootstrap-tab-history-rails
   by_star!
   byebug
   committee (~> 4.4)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,6 +14,7 @@
 //= require jquery.turbolinks
 //= require jquery_ujs
 //= require bootstrap-sprockets
+//= require bootstrap-tab-history
 //= require cytoscape
 //= require cytoscape-panzoom
 //= require jscolor

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -293,6 +293,9 @@ module ApplicationHelper
         options['data-toggle'] = 'tooltip'
       else
         options['data-toggle'] = 'tab'
+        options['data-tab-history'] = true
+        options['data-tab-history-changer'] = 'push'
+        options['data-tab-history-update-url'] = true
       end
 
       text << " (#{count})" if count

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -294,7 +294,7 @@ module ApplicationHelper
       else
         options['data-toggle'] = 'tab'
         options['data-tab-history'] = true
-        options['data-tab-history-changer'] = 'push'
+        options['data-tab-history-changer'] = 'replace'
         options['data-tab-history-update-url'] = true
       end
 


### PR DESCRIPTION
**Summary of changes**

- Automatically switch to anchored tags on load
- Push tab switches onto history

**Motivation and context**

I'd like to be able to deeplink to the calendar / map views

Note that we'd need to update that tab since it only loads the calendar once we click (and I expect the map to behave the same?)
 
**Screenshots**


**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
