### PR TITLE
Hide map on index page if no API key. Fixes #879

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -229,9 +229,7 @@ class Event < ApplicationRecord
   end
 
   def show_map?
-    Rails.application.secrets.google_maps_api_key.present? && # !self.online? &&
-      ((latitude.present? && longitude.present?) ||
-        (suggested_latitude.present? && suggested_longitude.present?))
+    TeSS::Config.map_enabled && ((latitude.present? && longitude.present?) || (suggested_latitude.present? && suggested_longitude.present?))
   end
 
   def all_day?

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -21,7 +21,7 @@
     <% content_for :display_options do %>
       <ul class="nav nav-xs nav-pills index-display-options">
         <%= tab('List', 'fa fa-list', 'home', active: true) %>
-        <% if !TeSS::Config.feature['disabled'].include? 'events_map' %>
+        <% if TeSS::Config.map_enabled %>
           <%= tab('Map', 'fa fa-globe', 'map',
                   disabled: { check: (search_and_facet_params[:online] == 'true'),
                               message: 'Only showing online events.' }) %>
@@ -42,7 +42,7 @@
           <%= render partial: "search/common/pagination_bar", locals: { resources: @events } %>
         </div>
 
-        <% unless TeSS::Config.feature['disabled'].include?('events_map') %>
+        <% if TeSS::Config.map_enabled %>
           <div id="map" class="tab-pane fade">
             <div id="map-count" class="search-results-count"></div>
             <div id="map-content">

--- a/test/config/test_secrets.yml
+++ b/test/config/test_secrets.yml
@@ -1,4 +1,4 @@
-google_maps_api_key:
+google_maps_api_key: 123xyz
 recaptcha:
   sitekey: test
   secret: test

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -1324,6 +1324,9 @@ class EventsControllerTest < ActionController::TestCase
   end
 
   test 'should hide map tab if disabled' do
+    assert Rails.application.secrets.google_maps_api_key.present?
+    assert TeSS::Config.map_enabled
+
     get :index
     assert_response :success
     assert_select '#content .nav' do
@@ -1331,6 +1334,22 @@ class EventsControllerTest < ActionController::TestCase
     end
 
     with_settings(feature: { disabled: ['events_map'] }) do
+      assert Rails.application.secrets.google_maps_api_key.present?
+      refute TeSS::Config.map_enabled
+
+      get :index
+      assert_response :success
+      assert_select '#content .nav' do
+        assert_select 'li a[href=?]', '#map', count: 0
+      end
+    end
+  end
+
+  test 'should hide map tab if no API key' do
+    Rails.application.secrets.stub(:google_maps_api_key, nil) do
+      refute Rails.application.secrets.google_maps_api_key.present?
+      refute TeSS::Config.map_enabled
+
       get :index
       assert_response :success
       assert_select '#content .nav' do
@@ -1353,5 +1372,27 @@ class EventsControllerTest < ActionController::TestCase
     sign_in users(:another_regular_user)
     get :clone, params: { id: @event }
     assert_response :forbidden
+  end
+
+  test 'should show map if location data' do
+    get :show, params: { id: events(:one) }
+    assert_response :success
+    assert_select '#map'
+  end
+
+  test 'should not show map if no location data' do
+    get :show, params: { id: events(:portal_event) }
+    assert_response :success
+    assert_select '#map', count: 0
+  end
+
+  test 'should not show map if disabled' do
+    with_settings(feature: { disabled: ['events_map'] }) do
+      assert Rails.application.secrets.google_maps_api_key.present?
+      refute TeSS::Config.map_enabled
+      get :show, params: { id: events(:one) }
+      assert_response :success
+      assert_select '#map', count: 0
+    end
   end
 end

--- a/test/fixtures/edit_suggestions.yml
+++ b/test/fixtures/edit_suggestions.yml
@@ -17,3 +17,8 @@ multiple_fields:
   data_fields:
     title: banana
     latitude: 15
+
+location_suggestions:
+  suggestible: kilburn (Event)
+  data_fields:
+    geographic_coordinates: [43, 43]

--- a/test/integration/cookie_consent_integration_test.rb
+++ b/test/integration/cookie_consent_integration_test.rb
@@ -16,7 +16,7 @@ class CookieConsentIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test 'cookie consent banner shown with tracking option if analytics enabled' do
-    with_settings({ require_cookie_consent: true, analytics_enabled: true }) do
+    with_settings({ require_cookie_consent: true, force_analytics_enabled: true }) do
       get root_path
 
       assert_select '#cookie-banner' do
@@ -51,7 +51,7 @@ class CookieConsentIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test 'analytics code not present if only necessary cookies allowed' do
-    with_settings({ require_cookie_consent: true, analytics_enabled: true }) do
+    with_settings({ require_cookie_consent: true, force_analytics_enabled: true }) do
       post cookies_consent_path, params: { allow: 'necessary' }
 
       get root_path
@@ -62,7 +62,7 @@ class CookieConsentIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test 'analytics code present if only all cookies allowed' do
-    with_settings({ require_cookie_consent: true, analytics_enabled: true }) do
+    with_settings({ require_cookie_consent: true, force_analytics_enabled: true }) do
       post cookies_consent_path, params: { allow: all_options }
 
       get root_path
@@ -73,7 +73,7 @@ class CookieConsentIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test 'analytics code present if cookie consent not required' do
-    with_settings({ require_cookie_consent: false, analytics_enabled: true }) do
+    with_settings({ require_cookie_consent: false, force_analytics_enabled: true }) do
       post cookies_consent_path, params: { allow: 'necessary' }
 
       get root_path
@@ -86,7 +86,7 @@ class CookieConsentIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test 'can access and use cookie consent page as anonymous user' do
-    with_settings({ require_cookie_consent: true, analytics_enabled: true }) do
+    with_settings({ require_cookie_consent: true, force_analytics_enabled: true }) do
       get cookies_consent_path
 
       assert_nil User.current_user
@@ -122,7 +122,7 @@ class CookieConsentIntegrationTest < ActionDispatch::IntegrationTest
     user = users(:regular_user)
     post '/users/sign_in', params: { 'user[login]' => user.username, 'user[password]' => 'hello' }
 
-    with_settings({ require_cookie_consent: true, analytics_enabled: true }) do
+    with_settings({ require_cookie_consent: true, force_analytics_enabled: true }) do
       get cookies_consent_path
 
       assert_equal user, User.current_user
@@ -152,7 +152,7 @@ class CookieConsentIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test 'revoke consent' do
-    with_settings({ require_cookie_consent: true, analytics_enabled: true }) do
+    with_settings({ require_cookie_consent: true, force_analytics_enabled: true }) do
       post cookies_consent_path, params: { allow: 'necessary' }
       follow_redirect!
       assert_select '#flash-container .alert-danger', count: 0

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -543,4 +543,18 @@ class EventTest < ActiveSupport::TestCase
     assert_equal 'Event  Title', @event.title
     assert_equal 'https://event.com', @event.url
   end
+
+  test 'show_map?' do
+    assert TeSS::Config.map_enabled
+
+    assert events(:one).show_map?
+    refute events(:portal_event).show_map?
+    assert events(:kilburn).suggested_latitude
+    assert events(:kilburn).show_map?
+
+    with_settings(feature: { disabled: ['events_map'] }) do
+      refute TeSS::Config.map_enabled
+      refute events(:one).show_map?
+    end
+  end
 end


### PR DESCRIPTION
**Summary of changes**

- Hide map on index page if no API key.
- Tweak custom Config getters to be dynamic.

**Motivation and context**

#879

Setting derived `TeSS::Config` properties on boot (e.g. `map_enabled`) made it hard to switch when testing.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
