### PR TITLE
Search tabs

### DIFF
--- a/app/views/content_providers/show.html.erb
+++ b/app/views/content_providers/show.html.erb
@@ -36,7 +36,7 @@
                 disabled: { check: events_count.zero?, message: 'No associated events' },
                 count: events_count) %>
 
-        <% if TeSS::Config.feature['user_source_creation'] && policy(@content_provider).update? %>
+        <% if TeSS::Config.feature['sources'] && policy(@content_provider).update? %>
           <%= tab('Sources', icon_class_for_model('sources'), 'sources', count: sources.count, activator: activator) %>
         <% end %>
       </ul>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -12,18 +12,17 @@
     <p class="empty">No results found</p>
   <% else %>
     <% tabs = @results.keys.sort_by { |k| TeSS::Config.site['tab_order'].index(k.to_s) || 99 } %>
+    <% activator = tab_activator %>
     <ul class="nav nav-tabs">
-      <% tabs.each_with_index do |tab, index| %>
-        <li class="<%= index == 0 ? 'active' : '' %>">
-          <a data-toggle="tab" href="#<%= tab %>"><i class="<%= icon_class_for_model(tab) %>"></i> <%= tab.to_s.humanize.capitalize %>
-            (<%= @results[tab].total %>)</a>
-        </li>
+      <% tabs.each do |tab| %>
+        <%= tab(tab.to_s.humanize.capitalize, icon_class_for_model(tab), tab, activator: activator,
+                disabled: { check: @results[tab].total.zero? }, count: @results[tab].total) %>
       <% end %>
     </ul>
 
     <div class="tab-content">
       <% @results.each do |model, results_for_model| %>
-        <div class="tab-pane fade in <%= 'active'.html_safe if model == tabs.first %>" id="<%= model %>">
+        <div class="tab-pane fade <%= 'in active'.html_safe if activator.check_pane(model) %>" id="<%= model %>">
           <div class="search-results-count my-3">
             Showing <%= pluralize(results_for_model.results.count, model.to_s.humanize.downcase.singularize) %>
             <% if results_for_model.total > page_size %>


### PR DESCRIPTION
**Summary of changes**

- Re-use tab helpers for search result tabs.
- Fix wrong setting hiding the sources tab on content provider page.

**Motivation and context**

- Search tabs were not making use of tab history.
- Sources tab should be visible to admins even if users can't create them.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
