### PR TITLE
configurable content provider sidebar

### DIFF
--- a/app/views/content_providers/partials/_content_provider_sidebar.html.erb
+++ b/app/views/content_providers/partials/_content_provider_sidebar.html.erb
@@ -1,8 +1,10 @@
-<h4 class="nav-heading">Type</h4>
-<div class="nav-block">
-  <%= content_provider.content_provider_type %>
-</div>
-<% unless content_provider.keywords.blank? %>
+<% unless TeSS::Config.site['content_provider_sidebar_skip'].include?('type') %>
+  <h4 class="nav-heading">Type</h4>
+  <div class="nav-block">
+    <%= content_provider.content_provider_type %>
+  </div>
+<% end %>
+<% unless content_provider.keywords.blank? || TeSS::Config.site['content_provider_sidebar_skip'].include?('keywords') %>
   <h4 class="nav-heading">Keywords</h4>
   <div class="nav-block">
     <%= content_provider.keywords.join(', ') %>
@@ -21,7 +23,7 @@
     </p>
   </div>
 <% end %>
-<% unless @content_provider.contact.blank? %>
+<% unless @content_provider.contact.blank? || TeSS::Config.site['content_provider_sidebar_skip'].include?('contact') %>
   <h4 class="nav-heading">Contact</h4>
   <div class="nav-block">
     <%= content_provider.contact %>
@@ -33,11 +35,13 @@
 
 <%= render partial: 'content_providers/partials/twitter_card',
            locals: { content_provider: @content_provider } %>
-<h4 class="nav-heading">Owner</h4>
-<div class="nav-block">
-  <%= link_to content_provider.user.name, content_provider.user %>
-</div>
-<% if content_provider.editors.any? %>
+<% unless TeSS::Config.site['content_provider_sidebar_skip'].include?('owner') %>
+  <h4 class="nav-heading">Owner</h4>
+  <div class="nav-block">
+    <%= link_to content_provider.user.name, content_provider.user %>
+  </div>
+<% end %>
+<% unless !content_provider.editors.any? || TeSS::Config.site['content_provider_sidebar_skip'].include?('editors') %>
   <h4 class="nav-heading"><%= ContentProvider.human_attribute_name(:editors) %></h4>
   <% content_provider.editors.each do |editor| %>
     <div class="nav-block">

--- a/app/views/content_providers/partials/_content_provider_sidebar.html.erb
+++ b/app/views/content_providers/partials/_content_provider_sidebar.html.erb
@@ -1,10 +1,10 @@
-<% unless TeSS::Config.feature['content_provider_disabled'].include?('type') %>
+<% unless TeSS::Config.feature['content_providers_disabled'].include?('type') %>
   <h4 class="nav-heading">Type</h4>
   <div class="nav-block">
     <%= content_provider.content_provider_type %>
   </div>
 <% end %>
-<% unless content_provider.keywords.blank? || TeSS::Config.feature['content_provider_disabled'].include?('keywords') %>
+<% unless content_provider.keywords.blank? || TeSS::Config.feature['content_providers_disabled'].include?('keywords') %>
   <h4 class="nav-heading">Keywords</h4>
   <div class="nav-block">
     <%= content_provider.keywords.join(', ') %>
@@ -23,7 +23,7 @@
     </p>
   </div>
 <% end %>
-<% unless @content_provider.contact.blank? || TeSS::Config.feature['content_provider_disabled'].include?('contact') %>
+<% unless @content_provider.contact.blank? || TeSS::Config.feature['content_providers_disabled'].include?('contact') %>
   <h4 class="nav-heading">Contact</h4>
   <div class="nav-block">
     <%= content_provider.contact %>
@@ -35,13 +35,13 @@
 
 <%= render partial: 'content_providers/partials/twitter_card',
            locals: { content_provider: @content_provider } %>
-<% unless TeSS::Config.feature['content_provider_disabled'].include?('owner') %>
+<% unless TeSS::Config.feature['content_providers_disabled'].include?('owner') %>
   <h4 class="nav-heading">Owner</h4>
   <div class="nav-block">
     <%= link_to content_provider.user.name, content_provider.user %>
   </div>
 <% end %>
-<% unless !content_provider.editors.any? || TeSS::Config.feature['content_provider_disabled'].include?('editors') %>
+<% unless !content_provider.editors.any? || TeSS::Config.feature['content_providers_disabled'].include?('editors') %>
   <h4 class="nav-heading"><%= ContentProvider.human_attribute_name(:editors) %></h4>
   <% content_provider.editors.each do |editor| %>
     <div class="nav-block">

--- a/app/views/content_providers/partials/_content_provider_sidebar.html.erb
+++ b/app/views/content_providers/partials/_content_provider_sidebar.html.erb
@@ -1,10 +1,10 @@
-<% unless TeSS::Config.site['content_provider_sidebar_skip'].include?('type') %>
+<% unless TeSS::Config.feature['content_provider_disabled'].include?('type') %>
   <h4 class="nav-heading">Type</h4>
   <div class="nav-block">
     <%= content_provider.content_provider_type %>
   </div>
 <% end %>
-<% unless content_provider.keywords.blank? || TeSS::Config.site['content_provider_sidebar_skip'].include?('keywords') %>
+<% unless content_provider.keywords.blank? || TeSS::Config.feature['content_provider_disabled'].include?('keywords') %>
   <h4 class="nav-heading">Keywords</h4>
   <div class="nav-block">
     <%= content_provider.keywords.join(', ') %>
@@ -23,7 +23,7 @@
     </p>
   </div>
 <% end %>
-<% unless @content_provider.contact.blank? || TeSS::Config.site['content_provider_sidebar_skip'].include?('contact') %>
+<% unless @content_provider.contact.blank? || TeSS::Config.feature['content_provider_disabled'].include?('contact') %>
   <h4 class="nav-heading">Contact</h4>
   <div class="nav-block">
     <%= content_provider.contact %>
@@ -35,13 +35,13 @@
 
 <%= render partial: 'content_providers/partials/twitter_card',
            locals: { content_provider: @content_provider } %>
-<% unless TeSS::Config.site['content_provider_sidebar_skip'].include?('owner') %>
+<% unless TeSS::Config.feature['content_provider_disabled'].include?('owner') %>
   <h4 class="nav-heading">Owner</h4>
   <div class="nav-block">
     <%= link_to content_provider.user.name, content_provider.user %>
   </div>
 <% end %>
-<% unless !content_provider.editors.any? || TeSS::Config.site['content_provider_sidebar_skip'].include?('editors') %>
+<% unless !content_provider.editors.any? || TeSS::Config.feature['content_provider_disabled'].include?('editors') %>
   <h4 class="nav-heading"><%= ContentProvider.human_attribute_name(:editors) %></h4>
   <% content_provider.editors.each do |editor| %>
     <div class="nav-block">

--- a/config/tess.example.yml
+++ b/config/tess.example.yml
@@ -42,6 +42,7 @@ default: &default
     directory_tabs: ['trainers', 'content_providers', 'nodes']
     # The order in with the 'about us' tabs appear
     about_us_tab_order: ['tess_club', 'contact', 'team', 'funding', 'acknowledgements', 'cite']
+    content_provider_sidebar_skip: []
     n_provider_ids: 5
   mailer:
     delivery_method: sendmail

--- a/config/tess.example.yml
+++ b/config/tess.example.yml
@@ -76,7 +76,7 @@ default: &default
     #  other_types, subsets, syllabus, approved_editors address_finder
     disabled: ['ardc_fields_of_research', 'other_types', 'subsets', 'syllabus', 'approved_editors']
     materials_disabled: []
-    content_provider_disabled: []
+    content_providers_disabled: []
   restrict_content_provider_selection: false
   user_ingestion_methods: ['bioschemas']
   placeholder:

--- a/config/tess.example.yml
+++ b/config/tess.example.yml
@@ -42,7 +42,6 @@ default: &default
     directory_tabs: ['trainers', 'content_providers', 'nodes']
     # The order in with the 'about us' tabs appear
     about_us_tab_order: ['tess_club', 'contact', 'team', 'funding', 'acknowledgements', 'cite']
-    content_provider_sidebar_skip: []
     n_provider_ids: 5
   mailer:
     delivery_method: sendmail
@@ -77,6 +76,7 @@ default: &default
     #  other_types, subsets, syllabus, approved_editors address_finder
     disabled: ['ardc_fields_of_research', 'other_types', 'subsets', 'syllabus', 'approved_editors']
     materials_disabled: []
+    content_provider_disabled: []
   restrict_content_provider_selection: false
   user_ingestion_methods: ['bioschemas']
   placeholder:


### PR DESCRIPTION
**Summary of changes**
Be able to disable 'Owner' and 'Type' in content provider sidebar for Taxila

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
