### PR TITLE
Report extra info when scraping/testing source

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -72,6 +72,16 @@ function reposition_tiles(container, tileClass){
 }
 
 document.addEventListener("turbolinks:load", function() {
+    // Show the tab associated with the window location hash (e.g. "#packages")
+    if (window.location.hash) {
+        var tab = $('ul.nav a[href="' + window.location.hash + '"]');
+        if (tab.length) {
+            // This terrible hack gets around the fact that event handlers in view templates get bound after the
+            // `tab.tab('show')` executes, so nothing happens.
+            setTimeout(function () { tab.tab("show"); }, 50);
+        }
+    }
+
     // Disabled tabs
     $(".nav-tabs li a[data-toggle='tooltip']").tooltip();
     $(".nav-tabs li.disabled a").click(function (e) { e.preventDefault(); return false });

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -830,7 +830,7 @@ input[type=checkbox].field-lock + label:before,
 }
 
 
-.description {
+.description, .source-log {
   border: 1px solid lightgrey;
   padding: 18px;
   border-radius: 5px;
@@ -982,4 +982,9 @@ div {
 .markdown-description {
   word-break: break-word;
   display: inline-block
+}
+
+.source-log {
+  max-height: 20pc;
+  overflow-y: scroll;
 }

--- a/app/controllers/sources_controller.rb
+++ b/app/controllers/sources_controller.rb
@@ -161,7 +161,7 @@ class SourcesController < ApplicationController
     if @content_provider
       add_base_breadcrumbs('content_providers')
       add_show_breadcrumb(@content_provider)
-      add_breadcrumb 'Sources'
+      add_breadcrumb 'Sources', content_provider_path(@content_provider, anchor: 'sources')
 
       if params[:id]
         add_breadcrumb @source.title, content_provider_source_path(@content_provider, @source) if (@source && !@source.new_record?)

--- a/app/views/sources/_test_results.html.erb
+++ b/app/views/sources/_test_results.html.erb
@@ -10,7 +10,9 @@
 </p>
 <% unless test_results[:messages].blank? %>
   <h5>Log</h5>
-  <%= content_tag(:pre, test_results[:messages].join("\n"), style: 'max-height: 20pc; overflow-y: scroll;') %>
+  <div class="markdown source-log">
+    <%= render_markdown(test_results[:messages].join("\n")) %>
+  </div>
 <% end %>
 
 <h5>Resources found:</h5>
@@ -50,12 +52,12 @@
             <%= display_attribute(resource, :timezone) %>
             <%= display_attribute(resource, :duration) %>
           <% end %>
+          <%= render partial: 'common/extra_metadata', locals: { resource: resource } %>
           <% unless resource.valid? %>
             <div class="alert alert-danger">
               <i class="fa fa-exclamation-circle"></i> Errors: <%= resource.errors.full_messages.join(', ') %>
             </div>
           <% end %>
-          <%= render partial: 'common/extra_metadata', locals: { resource: resource } %>
         </div>
       </div>
     <% end %>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -27,7 +27,6 @@
         <div id="home" class="tab-pane fade in active">
           <div class="my-3">
             <div>
-
               <h4>Source Details</h4>
 
               <!-- Field: URL -->
@@ -43,11 +42,11 @@
 
               <!-- Field: created at -->
               <p><strong>Created at:</strong>
-                <%= @source.created_at.strftime('%H:%M on %A, %d %B %Y (UTC)') %>
+                <%= @source.created_at.strftime('%A, %d %B %Y @ %H:%M') %>
               </p>
 
               <!-- Field: token -->
-              <% if !current_user.nil? and (current_user.is_curator? or current_user.is_admin?) %>
+              <% if current_user && (current_user.is_curator? || current_user.is_admin?) %>
                 <p><strong>Token:</strong>
                   <%= @source.token %>
                 </p>
@@ -80,58 +79,28 @@
               <hr/>
 
               <%# Show details of last run %>
-              <div class="row">
-                <div class="col-md-3">
-                  <h4>Last Run</h4>
-                  <% if @source.finished_at.nil? %>
-                    <p><strong>No results found</strong></p>
-                  <% else %>
-                    <p><strong>Finished at:</strong></p>
-                    <p><strong>Time:</strong>
-                      <%= @source.finished_at.strftime('%H:%M (UTC)') %>
-                    </p>
-                    <p><strong>Date:</strong>
-                      <%= @source.finished_at.strftime('%a, %d %B %Y') %>
-                    </p>
-                    <table class="table">
-                      <thead>
-                      <tr>
-                        <th scope="col">Records</th>
-                        <th scope="col">Count</th>
-                      </tr>
-                      </thead>
-                      <tr>
-                        <th scope="row">read</th>
-                        <td><%= @source.records_read %></td>
-                      </tr>
-                      <tr>
-                        <th scope="row">written</th>
-                        <td><%= @source.records_written %></td>
-                      </tr>
-                      <tr>
-                        <th scope="row">added</th>
-                        <td><%= @source.resources_added %></td>
-                      </tr>
-                      <tr>
-                        <th scope="row">updated</th>
-                        <td><%= @source.resources_updated %></td>
-                      </tr>
-                      <tr>
-                        <th scope="row">rejected</th>
-                        <td><%= @source.resources_rejected %></td>
-                      </tr>
-                    </table>
-                  <% end %>
-                </div>
+              <div>
+                <h4>Last Run</h4>
+                <% if @source.finished_at.nil? %>
+                  <p><strong>No results found</strong></p>
+                <% else %>
+                  <p>
+                    <strong>Finished:</strong> <%= time_ago_in_words(@source.finished_at) %> ago
+                    (<%= @source.finished_at.strftime('%A, %d %B %Y @ %H:%M') %>)
+                  </p>
+                  <strong>Resources:</strong>
+                  <ul>
+                    <li>Added: <span class="text-success"><%= @source.resources_added %></span></li>
+                    <li>Updated: <span class="text-warning"><%= @source.resources_updated %></span></li>
+                    <li>Rejected: <span class="text-danger"><%= @source.resources_rejected %></span></li>
+                  </ul>
+                <% end %>
 
                 <%# Show details of log %>
                 <% unless @source.log.nil? %>
-                  <div class="col-md-9">
-                    <h4>Output</h4>
-                    <div class="panel-body"
-                         style="width: 100%; height: 300px ;overflow-y: scroll">
-                      <%= render_markdown(@source.log.html_safe) %>
-                    </div>
+                  <h5>Log</h5>
+                  <div class="markdown source-log">
+                    <%= render_markdown(@source.log.html_safe) %>
                   </div>
                 <% end %>
               </div>

--- a/lib/ingestors/ingestor.rb
+++ b/lib/ingestors/ingestor.rb
@@ -41,7 +41,13 @@ module Ingestors
     end
 
     def stats_summary(type)
-      "#{type} " << [:processed, :added, :updated, :rejected].map { |key| "#{key}[#{stats[type][key]}]" }.join(' ')
+      summary = "\n### #{type.to_s.titleize}\n\n"
+
+      [:processed, :added, :updated, :rejected].each do |key|
+        summary += " - #{key.to_s.titleize}: #{stats[type][key]}\n"
+      end
+
+      summary
     end
 
     def open_url(url, raise: false)
@@ -145,9 +151,11 @@ module Ingestors
           @stats[key][update ? :updated : :added] += 1
         else
           @stats[key][:rejected] += 1
-          @messages << "#{type.model_name.human} failed validation: #{resource.title}"
+          title = resource.title
+          title = "[#{title}](#{resource.url})" if resource.url
+          @messages << "\n#{type.model_name.human} failed validation: #{title}\n"
           resource.errors.full_messages.each do |m|
-            @messages << "Error: #{m}"
+            @messages << " - #{m}"
           end
         end
 

--- a/test/unit/ingestors/bioschemas_ingestor_test.rb
+++ b/test/unit/ingestors/bioschemas_ingestor_test.rb
@@ -48,6 +48,9 @@ class BioschemasIngestorTest < ActiveSupport::TestCase
     @ingestor.read('https://training.galaxyproject.org/sitemap.xml')
     assert_equal 0, @ingestor.events.count
     assert_equal 3, @ingestor.materials.count
+    assert_includes @ingestor.messages, " - 6 URLs found"
+    assert_includes @ingestor.messages, " - Events: 0"
+    assert_includes @ingestor.messages, " - LearningResources: 3"
 
     assert_difference('Material.count', 3) do
       @ingestor.write(@user, @content_provider)


### PR DESCRIPTION
**Summary of changes**

- Report number of URLs crawled from sitemap in Bioschemas scraper.
- Report number of Bioschemas resources found.
- Improve the appearance of the output log (use of headings, grouping errors under each resource in a `ul`, etc.)
- Remove some redundant info (records read/written)
- Harmonize "Last Run" and "Test Result" views

**Motivation and context**

Was not always apparent why a source "didn't work".

#822
 
**Screenshots**

![image](https://github.com/ElixirTeSS/TeSS/assets/503373/d82fa106-d823-454f-98df-ddfc081dba67)


**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
