### PR TITLE
default of false for online in uva ingestor

### DIFF
--- a/lib/ingestors/uva_ingestor.rb
+++ b/lib/ingestors/uva_ingestor.rb
@@ -49,7 +49,7 @@ module Ingestors
         event.city = 'Amsterdam'
         event.country = 'The Netherlands'
         event.source = 'UvA'
-        event.online = attr.fetch('online_event', '')
+        event.online = attr.fetch('online_event', false)
         event.timezone = 'Amsterdam'
 
         # array fields


### PR DESCRIPTION
**Summary of changes**
default value of false for online in uva ingestor

**Motivation and context**
if page did not have the proper field to be scraped then there would be no value for online and the events would have a json instead of an icon for their online status
 
**Screenshots**

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
