### PR TITLE
Fix resources in JSON-LD snippets with relative `@id`s not being detected

### DIFF
--- a/app/controllers/bioschemas_controller.rb
+++ b/app/controllers/bioschemas_controller.rb
@@ -19,7 +19,7 @@ class BioschemasController < ApplicationController
       if body
         begin
           ingestor = Ingestors::BioschemasIngestor.new
-          @output = ingestor.read_content(StringIO.new(body), url: params[:url])
+          @output = ingestor.read_content(StringIO.new(body), url: params[:url] || 'https://example.com')
         rescue RDF::ReaderError
           flash[:error] = 'A parsing error occurred. Please check your document contains valid JSON-LD or HTML.'
           format.html { render :test, status: :unprocessable_entity }

--- a/test/controllers/bioschemas_controller_test.rb
+++ b/test/controllers/bioschemas_controller_test.rb
@@ -143,6 +143,19 @@ class BioschemasControllerTest < ActionController::TestCase
     assert_redirected_to new_user_session_path
   end
 
+  test 'should detect resources in JSON-LD snippet with relative IDs' do
+    sign_in users(:regular_user)
+
+    post :run_test, params: { snippet: fixture_file('ols_relative_id.json').read }
+
+    assert_response :success
+
+    output = assigns(:output)
+    assert_equal 1, output[:totals]['LearningResources']
+    assert_equal 1, output[:resources][:materials].count
+    assert_equal "https://test.url", output[:resources][:materials].first[:url]
+  end
+
   private
 
   def fixture_file(filename)

--- a/test/fixtures/files/ingestion/ols_relative_id.json
+++ b/test/fixtures/files/ingestion/ols_relative_id.json
@@ -1,0 +1,59 @@
+{
+  "@context": "https://schema.org",
+  "@type": "LearningResource",
+  "@id": "some%20id",
+  "url": "https://test.url",
+  "dct:conformsTo": {
+    "https://purl.org/dc/terms/conformsTo": {
+      "@id": "https://bioschemas.org/profiles/TrainingMaterial/1.0-RELEASE",
+      "@type": "CreativeWork"
+    }
+  },
+  "description": "Video from the talk 'Welcome to OLS!', by  Emmy Tsang, on March 07, 2022, in Open Seeds ols-5 cohort",
+  "keywords": ["Open Science", "Open Life Science", "OLS Introduction"],
+  "name": "Recording of the talk 'Welcome to OLS!', by  Emmy Tsang, on March 07, 2022",
+  "educationalLevel": "Beginner",
+  "inLanguage": "en-US",
+  "learningResourceType": "video",
+  "license": "https://creativecommons.org/licenses/by-sa/4.0/",
+  "contributor":  [
+    {
+      "@type": "Organization",
+      "name": "Open Life Science",
+      "email": "team@we-are-ols.org",
+      "url": "https://openlifesci.org/"
+    },{
+      "@type": "Person",
+      "name": "Emmy Tsang",
+      "url": "https://openlifesci.org//people#emmyft"
+    }],
+  "dateCreated": "2022-03-07",
+  "hasPart": {
+    "@type": "CreativeWork",
+    "url": "https://docs.google.com/presentation/d/1B-TiVAHx6OVririv88-H59_BlPwniS5xDnhZtoDU280/edit#slide=id.g6e457e6ac5_0_69",
+    "name": "Slides for the talk 'Welcome to OLS!', by  Emmy Tsang, on March 07, 2022"
+  },
+  "isPartOf": {
+    "@context": "https://schema.org",
+    "@type": "Course",
+    "@id": "https://openlifesci.org//ols-5",
+    "dct:conformsTo": {
+      "https://purl.org/dc/terms/conformsTo": {
+        "@id": "https://bioschemas.org/profiles/Course/1.0-RELEASE",
+        "@type": "CreativeWork"
+      }
+    },
+    "description": "OLS is a mentoring mentoring & training program for Open Science ambassadors. It runs cohorts with calls every 1-2 weeks.",
+    "keywords": "Open Science",
+    "name": "Open Seeds ols-5 cohort",
+    "url": "https://openlifesci.org//openseeds/ols-5",
+    "educationalLevel": "Beginner",
+    "inLanguage": "en-US",
+    "provider":  [{
+      "@type": "Organization",
+      "name": "Open Life Science",
+      "email": "team@we-are-ols.org",
+      "url": "https://openlifesci.org/"
+    }]
+  }
+}


### PR DESCRIPTION
**Summary of changes**

- Adds a dummy URL to the ingestor when testing Bioschemas content, allowing resources with relative `@id`s to be picked up.

**Motivation and context**

JSON snippets e.g. 
```json
{
        "@context": "https://schema.org",
        "@type": "LearningResource",
        "@id": "#some-resource"
}
```
were being ignored.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
