### PR TITLE
Synonyms for EDAM terms

### DIFF
--- a/app/models/concerns/has_edam_terms.rb
+++ b/app/models/concerns/has_edam_terms.rb
@@ -1,0 +1,15 @@
+module HasEdamTerms
+  extend ActiveSupport::Concern
+
+  def scientific_topics_and_synonyms
+    scientific_topics.map do |term|
+      [term.preferred_label] + term.has_exact_synonym + term.has_narrow_synonym
+    end.flatten.uniq
+  end
+
+  def operations_and_synonyms
+    operations.map do |term|
+      [term.preferred_label] + term.has_exact_synonym + term.has_narrow_synonym
+    end.flatten.uniq
+  end
+end

--- a/app/models/concerns/has_edam_terms.rb
+++ b/app/models/concerns/has_edam_terms.rb
@@ -2,13 +2,17 @@ module HasEdamTerms
   extend ActiveSupport::Concern
 
   def scientific_topics_and_synonyms
-    scientific_topics.map do |term|
-      [term.preferred_label] + term.has_exact_synonym + term.has_narrow_synonym
-    end.flatten.uniq
+    edam_term_names_and_synonyms(scientific_topics)
   end
 
   def operations_and_synonyms
-    operations.map do |term|
+    edam_term_names_and_synonyms(operations)
+  end
+
+  private
+
+  def edam_term_names_and_synonyms(terms)
+    terms.map do |term|
       [term.preferred_label] + term.has_exact_synonym + term.has_narrow_synonym
     end.flatten.uniq
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -17,6 +17,7 @@ class Event < ApplicationRecord
   include HasFriendlyId
   include FuzzyDictionaryMatch
   include WithTimezone
+  include HasEdamTerms
 
   before_validation :fix_keywords, on: :create, if: :scraper_record
   before_validation :presence_default
@@ -39,6 +40,12 @@ class Event < ApplicationRecord
       text :timezone
       text :content_provider do
         content_provider.title unless content_provider.nil?
+      end
+      text :scientific_topics do
+        scientific_topics_and_synonyms
+      end
+      text :operations do
+        scientific_topics_and_synonyms
       end
       # sort title
       string :sort_title do
@@ -70,10 +77,10 @@ class Event < ApplicationRecord
         associated_nodes.pluck(:name)
       end
       string :scientific_topics, multiple: true do
-        scientific_topic_names
+        scientific_topics_and_synonyms
       end
       string :operations, multiple: true do
-        operation_names
+        operations_and_synonyms
       end
       string :target_audience, multiple: true
       boolean :online do

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -45,7 +45,7 @@ class Event < ApplicationRecord
         scientific_topics_and_synonyms
       end
       text :operations do
-        scientific_topics_and_synonyms
+        operations_and_synonyms
       end
       # sort title
       string :sort_title do

--- a/app/models/material.rb
+++ b/app/models/material.rb
@@ -15,6 +15,7 @@ class Material < ApplicationRecord
   include IdentifiersDotOrg
   include HasFriendlyId
   include HasDifficultyLevel
+  include HasEdamTerms
 
   if TeSS::Config.solr_enabled
     # :nocov:
@@ -32,6 +33,12 @@ class Material < ApplicationRecord
       text :content_provider do
         self.content_provider.try(:title)
       end
+      text :scientific_topics do
+        scientific_topics_and_synonyms
+      end
+      text :operations do
+        scientific_topics_and_synonyms
+      end
       # sort title
       string :sort_title do
         title.downcase.gsub(/^(an?|the) /, '')
@@ -40,10 +47,10 @@ class Material < ApplicationRecord
       string :title
       string :authors, :multiple => true
       string :scientific_topics, :multiple => true do
-        self.scientific_topic_names
+        scientific_topics_and_synonyms
       end
       string :operations, :multiple => true do
-        self.operation_names
+        operations_and_synonyms
       end
       string :target_audience, :multiple => true
       string :keywords, :multiple => true

--- a/app/models/material.rb
+++ b/app/models/material.rb
@@ -37,7 +37,7 @@ class Material < ApplicationRecord
         scientific_topics_and_synonyms
       end
       text :operations do
-        scientific_topics_and_synonyms
+        operations_and_synonyms
       end
       # sort title
       string :sort_title do

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -10,6 +10,7 @@ class Workflow < ApplicationRecord
   include HasFriendlyId
   include CurationQueue
   include HasDifficultyLevel
+  include HasEdamTerms
 
   if TeSS::Config.solr_enabled
     # :nocov:
@@ -28,9 +29,12 @@ class Workflow < ApplicationRecord
         node_index('description')
       end
       text :authors
+      text :scientific_topics do
+        scientific_topics_and_synonyms
+      end
       string :authors, :multiple => true
       string :scientific_topics, :multiple => true do
-        self.scientific_topic_names
+        scientific_topics_and_synonyms
       end
       text :target_audience
       string :target_audience, :multiple => true

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -654,4 +654,21 @@ class EventTest < ActiveSupport::TestCase
       refute @event.valid?
     end
   end
+
+  test 'scientific_topics_and_synonyms' do
+    @event.scientific_topic_names = ['Data governance']
+    @event.save!
+    assert_equal ['Data governance', 'Data stewardship'], @event.reload.scientific_topics_and_synonyms
+
+    @event.scientific_topic_names = ['Data governance', 'Data stewardship']
+    @event.save!
+    assert_equal ['Data governance', 'Data stewardship'], @event.reload.scientific_topics_and_synonyms
+  end
+
+  test 'operations_and_synonyms' do
+    @event.operation_names = ['Fold recognition', 'Fold prediction']
+    @event.save!
+    assert_equal ['Fold recognition', 'Domain prediction', 'Fold prediction', 'Protein domain prediction',
+                  'Protein fold prediction', 'Protein fold recognition'], @event.reload.operations_and_synonyms
+  end
 end


### PR DESCRIPTION
**Summary of changes**

- Index content by EDAM topic/operation synonyms as well as their exact names.
- Allow content to be queried by EDAM topic/operation (instead of just filtering).

**Motivation and context**

https://docs.google.com/document/d/1Qt6ABVqkDRTulg6ZhLsKu8YYlGbvD-xQvQGoVHuUwow/edit
@bianchini88

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
