### PR TITLE
Enable Content-Security-Policy and Feature-Policy headers

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,17 +4,17 @@
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-# Rails.application.config.content_security_policy do |policy|
-#   policy.default_src :self, :https
-#   policy.font_src    :self, :https, :data
-#   policy.img_src     :self, :https, :data
-#   policy.object_src  :none
-#   policy.script_src  :self, :https
-#   policy.style_src   :self, :https
+Rails.application.config.content_security_policy do |policy|
+  policy.default_src :self, :https
+  policy.font_src    :self, :https, :data
+  policy.img_src     :self, :https, :data
+  policy.object_src  :none
+  policy.script_src  :self, :https, :'unsafe_inline' # Turbolinks uses this, and using nonces breaks inline styles (below)
+  policy.style_src   :self, :https, :'unsafe_inline' # Inline styles :(
 
-#   # Specify URI for violation reports
-#   # policy.report_uri "/csp-violation-report-endpoint"
-# end
+  # Specify URI for violation reports
+  # policy.report_uri "/csp-violation-report-endpoint"
+end
 
 # If you are using UJS then enable automatic nonce generation
 # Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }

--- a/config/initializers/permissions_policy.rb
+++ b/config/initializers/permissions_policy.rb
@@ -1,0 +1,8 @@
+Rails.application.config.permissions_policy do |policy|
+  policy.camera      :none
+  policy.gyroscope   :none
+  policy.microphone  :none
+  policy.usb         :none
+  policy.fullscreen  :self
+  policy.payment     :none
+end

--- a/test/integration/header_test.rb
+++ b/test/integration/header_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class HeaderTest < ActionDispatch::IntegrationTest
+  test 'includes valid Content-Security-Policy header' do
+    get '/'
+
+    assert_response :success
+    assert response.headers.key?('Content-Security-Policy')
+    assert_includes response.headers['Content-Security-Policy'], "default-src 'self' https:;"
+    assert_includes response.headers['Content-Security-Policy'], "script-src 'self' https: 'unsafe-inline';"
+  end
+
+  test 'includes valid Feature-Policy header' do
+    get '/'
+
+    assert_response :success
+    assert response.headers.key?('Feature-Policy')
+    assert_includes response.headers['Feature-Policy'], "fullscreen 'self';"
+    assert_includes response.headers['Feature-Policy'], "camera 'none';"
+  end
+end


### PR DESCRIPTION
**Summary of changes**

- Adds Content-Security-Policy and Feature-Policy headers to responses.

**Motivation and context**

#865
 
**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
