### PR TITLE
add option to use a specific csp reporting endpoint

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -13,7 +13,7 @@ Rails.application.config.content_security_policy do |policy|
   policy.style_src   :self, :https, :'unsafe_inline' # Inline styles :(
 
   # Specify URI for violation reports
-  # policy.report_uri "/csp-violation-report-endpoint"
+  policy.report_uri TeSS::Config.csp_report_uri if TeSS::Config.csp_report_uri
 end
 
 # If you are using UJS then enable automatic nonce generation

--- a/config/tess.example.yml
+++ b/config/tess.example.yml
@@ -16,6 +16,7 @@ default: &default
   blocked_domains:
     - !ruby/regexp '/bad-domain\.example/'
   sentry_dsn:
+  csp_report_uri: 
   site:
     title: 'TeSS (Training eSupport System)'
     title_short: TeSS


### PR DESCRIPTION
**Summary of changes**
- add a csp_report_uri

**Motivation and context**
can be used with sentry


**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
