### PR TITLE
Fix deeply nested `ActionController::Parameters` breaking source test

### DIFF
--- a/app/assets/javascripts/sources.js
+++ b/app/assets/javascripts/sources.js
@@ -19,7 +19,7 @@ const Sources = {
                         error: function (data) {
                             console.log('error', data);
                             $('#test-status').text('');
-                            $('#test-errors').show().text('There was a problem rendering the results. ' + data.responseText);
+                            $('#test-errors').show().text('There was a problem rendering the results.');
                         },
                         complete: function () {
                             spinner.hide();

--- a/app/models/concerns/has_test_job.rb
+++ b/app/models/concerns/has_test_job.rb
@@ -30,7 +30,7 @@ module HasTestJob
 
   def test_results=(results)
     File.open(test_results_path, 'w') do |file|
-      file.write(results.to_yaml)
+      file.write(deep_hashify(results).to_yaml)
     end
   end
 
@@ -54,5 +54,17 @@ module HasTestJob
   def test_results_path
     path_id = Rails.env.test? ? "fakeid_#{model_name.singular}_#{id}" : test_job_id
     File.join(Rails.root, 'tmp', "test_results_#{path_id}.yml")
+  end
+
+  def deep_hashify(params)
+    params = params.to_h if params.is_a?(OpenStruct) || params.is_a?(ActionController::Parameters)
+
+    if params.is_a?(Hash)
+      params.transform_values { |v| deep_hashify(v) }
+    elsif params.is_a?(Array)
+      params.map { |p| deep_hashify(p) }
+    else
+      params
+    end
   end
 end

--- a/app/workers/source_test_worker.rb
+++ b/app/workers/source_test_worker.rb
@@ -21,8 +21,8 @@ class SourceTestWorker
       ingestor.token = source.token
       ingestor.read(source.url)
       results = {
-        events: ingestor.events.map { |r| r.to_h },
-        materials: ingestor.materials.map { |r| r.to_h },
+        events: ingestor.events,
+        materials: ingestor.materials,
         messages: ingestor.messages,
       }
     rescue StandardError => e

--- a/test/fixtures/files/ingestion/mentions.jsonld
+++ b/test/fixtures/files/ingestion/mentions.jsonld
@@ -1,0 +1,87 @@
+{
+  "@context": "https://schema.org/",
+  "@type": "LearningResource",
+  "http://purl.org/dc/terms/conformsTo": [
+    {
+      "@id": "https://bioschemas.org/profiles/TrainingMaterial/1.0-RELEASE",
+      "@type": "CreativeWork"
+    }
+  ],
+  "description": "A short introduction to the dancing principles and their origin",
+  "keywords": "dancing, principles, nutshell",
+  "name": "helloworld tutorial. dancing in a nutshell",
+  "about": [
+    {
+      "@id": "https://fellowship.somewesbite.org/latest/helloworld-tutorial-dancing-in-a-nutshell"
+    },
+    {
+      "@id": "https://bioportal.someotherwebsite.org/ontologies/FDT-O"
+    }
+  ],
+  "abstract": "A short introduction to the dancing principles and their origin",
+  "audience": [
+    {
+      "@type": "Audience",
+      "audienceType": "Trainers, people interested in dancing"
+    }
+  ],
+  "author": [
+    {
+      "@type": "Person",
+      "name": "Some One"
+    },
+    {
+      "@type": "Person",
+      "name": "Some One Else"
+    }
+  ],
+  "competencyRequired": [
+    {
+      "@type": "DefinedTerm",
+      "name": "dancing, workflows, and research",
+      "url": "https://training.athirdwebsite.org/training-material/topics/dancing/"
+    }
+  ],
+  "educationalLevel": "Beginner",
+  "identifier": "https://fellowship.somewebsite.org/latest/helloworld-tutorial-dancing-in-a-nutshell",
+  "inLanguage": "en-US",
+  "learningResourceType": "hands on",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "mentions": [
+    {
+      "@type": "Article",
+      "@id": "https://doi.org/10.1086/679716",
+      "name": "An Article About Something",
+      "identifier": "DOI:10.1086/679716",
+      "url": "https://doi.org/10.1086/679716"
+    }
+  ],
+  "teaches": [
+    "A short introduction to the dancing principles and their origin"
+  ],
+  "timeRequired": "PT10M",
+  "url": "https://training.athirdwebsite.org/training-material/topics/dancing/",
+  "accessibilitySummary": "Visual elements are not described",
+  "contributor": [
+    {
+      "@type": "Person",
+      "name": "Some One"
+    },
+    {
+      "@type": "Person",
+      "name": "Some One Else"
+    }
+  ],
+  "creativeWorkStatus": "Published",
+  "dateCreated": "2023-11-03T00:00:00Z",
+  "dateModified": "2023-11-03T00:00:00Z",
+  "datePublished": "2023-11-03T00:00:00Z",
+  "recordedAt": [
+    {
+      "@type": "Event",
+      "name": "dancing in a nutshell",
+      "url": "https://training.athirdwebsite.org/training-material/topics/dancing/tutorials/dancing-intro/tutorial.html"
+    }
+  ],
+  "version": "0.0.1"
+}


### PR DESCRIPTION
**Summary of changes**

- Ensure only "safe" types are written to the source test result YAML.

**Motivation and context**

Bioschemas sources with `mentions` (parsed as external resources) were breaking the source testing page.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
