### PR TITLE
Don't attempt to parse content when testing URLs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -60,8 +60,8 @@ class ApplicationController < ActionController::Base
       uri = URI.parse(params[:url]) rescue nil
       if uri && (uri.scheme == 'http' || uri.scheme == 'https')
         PrivateAddressCheck.only_public_connections do
-          res = HTTParty.get(uri.to_s, { timeout: 5 })
-          body = { code: res.code, message: res.message }
+          res = HTTParty.get(uri.to_s, timeout: 5, format: :plain)
+          body = { code: res.code, message: 'OK' }
         end
       else
         body = { message: 'Invalid URL - Make sure the URL starts with "https://" or "http://"' }

--- a/app/controllers/bioschemas_controller.rb
+++ b/app/controllers/bioschemas_controller.rb
@@ -39,7 +39,7 @@ class BioschemasController < ApplicationController
       uri = URI.parse(params[:url]) rescue nil
       if uri && (uri.scheme == 'http' || uri.scheme == 'https')
         PrivateAddressCheck.only_public_connections do
-          res = HTTParty.get(uri.to_s, { timeout: 5 })
+          res = HTTParty.get(uri.to_s, timeout: 5, format: :plain)
           if res.code == 200
             res.body
           else

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -10,6 +10,9 @@ class ApplicationControllerTest < ActionController::TestCase
     WebMock.stub_request(:any, 'http://500host.com').to_return(status: 500, body: 'hi')
     WebMock.stub_request(:any, 'http://slowhost.com').to_timeout
     WebMock.stub_request(:any, 'http://notrealhost.goldfish').to_raise(SocketError)
+    WebMock.stub_request(:any, 'http://badformathost.com').to_return(status: 200,
+                                                                     body: '<h1>Not really JSON</h1>',
+                                                                     headers: { content_type: 'application/json' })
 
     sign_in users(:regular_user)
   end
@@ -23,6 +26,9 @@ class ApplicationControllerTest < ActionController::TestCase
 
     get :test_url, params: { url: 'http://500host.com', format: :json }
     assert_equal 500, JSON.parse(response.body)['code']
+
+    get :test_url, params: { url: 'http://badformathost.com', format: :json }
+    assert_equal 200, JSON.parse(response.body)['code']
 
     get :test_url, params: { url: 'http://slowhost.com', format: :json }
     assert_equal 'Could not access the given URL', JSON.parse(response.body)['message']


### PR DESCRIPTION
**Summary of changes**

- Add the `format: :plain` option to HTTParty calls to disregard incoming content-type to ensure response isn't parsed.

**Motivation and context**

An endpoint with a JSON `Content-Type` header, but containing HTML caused a 500 error.
 
**Screenshots**

(Paste or upload any relevant screenshots)

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
