### PR TITLE
Handle and log errors when ingesting bioschemas content

### DIFF
--- a/app/controllers/bioschemas_controller.rb
+++ b/app/controllers/bioschemas_controller.rb
@@ -19,7 +19,7 @@ class BioschemasController < ApplicationController
       if body
         begin
           ingestor = Ingestors::BioschemasIngestor.new
-          @output = ingestor.read_content(StringIO.new(body), url: params[:url] || 'https://example.com')
+          @output = ingestor.read_content(StringIO.new(body), url: params[:url] || Ingestors::BioschemasIngestor::DUMMY_URL).merge(messages: ingestor.messages)
         rescue RDF::ReaderError
           flash[:error] = 'A parsing error occurred. Please check your document contains valid JSON-LD or HTML.'
           format.html { render :test, status: :unprocessable_entity }

--- a/app/views/bioschemas/_test_results.html.erb
+++ b/app/views/bioschemas/_test_results.html.erb
@@ -24,12 +24,22 @@
     <% end %>
   </div>
   <div class="col-md-8 col-md-pull-4">
+    <% unless @output[:messages].blank? %>
+      <h5>Log</h5>
+      <div class="markdown source-log">
+        <%= render_markdown(@output[:messages].join("\n\n")) %>
+      </div>
+    <% end %>
     <h4>Bioschemas summary:</h4>
-    <table class="table" style="max-width: 20em">
-      <% @output[:totals].each do |type, total| %>
-        <tr><td><%= type %></td><td><%= total %></td></tr>
-      <% end %>
-    </table>
+    <% if @output[:totals].values.sum.zero? %>
+      <span class="muted">Nothing found</span>
+    <% else %>
+      <table class="table" style="max-width: 20em">
+        <% @output[:totals].each do |type, total| %>
+          <tr><td><%= type %></td><td><%= total %></td></tr>
+        <% end %>
+      </table>
+    <% end %>
   </div>
 </div>
 

--- a/app/views/sources/_test_results.html.erb
+++ b/app/views/sources/_test_results.html.erb
@@ -11,7 +11,7 @@
 <% unless test_results[:messages].blank? %>
   <h5>Log</h5>
   <div class="markdown source-log">
-    <%= render_markdown(test_results[:messages].join("\n")) %>
+    <%= render_markdown(test_results[:messages].join("\n\n")) %>
   </div>
 <% end %>
 

--- a/test/controllers/bioschemas_controller_test.rb
+++ b/test/controllers/bioschemas_controller_test.rb
@@ -92,8 +92,9 @@ class BioschemasControllerTest < ActionController::TestCase
 
     post :run_test, params: { snippet: "{ 'oh dear }" }
 
-    assert_response :unprocessable_entity
-    assert flash[:error].include?('parsing error')
+    assert_response :success
+    assert_select '.source-log', text:
+      'A parsing error occurred while reading the source. Please check your page contains valid JSON-LD or HTML.'
   ensure
     JSON::LD::Reader.define_method(old_method.name, old_method)
   end
@@ -111,8 +112,9 @@ class BioschemasControllerTest < ActionController::TestCase
 
     post :run_test, params: { url: 'https://website.com/material.json' }
 
-    assert_response :unprocessable_entity
-    assert flash[:error].include?('parsing error')
+    assert_response :success
+    assert_select '.source-log', text:
+      'A parsing error occurred while reading: https://website.com/material.json . Please check your page contains valid JSON-LD or HTML.'
   ensure
     JSON::LD::Reader.define_method(old_method.name, old_method)
   end

--- a/test/unit/ingestors/bioschemas_ingestor_test.rb
+++ b/test/unit/ingestors/bioschemas_ingestor_test.rb
@@ -48,9 +48,10 @@ class BioschemasIngestorTest < ActiveSupport::TestCase
     @ingestor.read('https://training.galaxyproject.org/sitemap.xml')
     assert_equal 0, @ingestor.events.count
     assert_equal 3, @ingestor.materials.count
-    assert_includes @ingestor.messages, " - 6 URLs found"
-    assert_includes @ingestor.messages, " - Events: 0"
-    assert_includes @ingestor.messages, " - LearningResources: 3"
+    messages = @ingestor.messages.join("\n")
+    assert_includes messages, "\n - 6 URLs found"
+    assert_includes messages, "\n - Events: 0"
+    assert_includes messages, "\n - LearningResources: 3"
 
     assert_difference('Material.count', 3) do
       @ingestor.write(@user, @content_provider)


### PR DESCRIPTION
**Summary of changes**

- Catches and logs exceptions that occur when scraping Bioschemas sources.
- Fixes awkward formatting of error messages when markdown is rendered.

**Motivation and context**

A user was trying to test a Bioschemas source, and a single page with a JSON error caused the entire ingestion to fail with a generic error message.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
