### PR TITLE
add register as trainer button that directs to user edit

### DIFF
--- a/app/views/trainers/index.html.erb
+++ b/app/views/trainers/index.html.erb
@@ -9,6 +9,9 @@
   <div id="content">
     <h2><%=t("features.trainers.long")%></h2>
     <% content_for :buttons do %>
+      <!-- Register button -->
+      <%= edit_button(current_user, text: 'Register as trainer') if current_user && policy(current_user).update? %>
+      <!-- Info -->
       <%= info_button("What are trainers in #{TeSS::Config.site['title_short']}?", hide_text: true) do %>
         <%= render_markdown(TrainersHelper::TRAINERS_INFO) %>
       <% end %>


### PR DESCRIPTION
**Summary of changes**
Button on trainer page that lets people register themselves

**Motivation and context**
Many people have trouble finding where to register as trainer

**Screenshots**

(Paste or upload any relevant screenshots)

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
