### PR TITLE
upcoming events on home page

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,6 +1,5 @@
 # The controller for actions related to home page
 class StaticController < ApplicationController
-
   skip_before_action :authenticate_user!, :authenticate_user_from_token!
 
   def privacy; end
@@ -20,6 +19,18 @@ class StaticController < ApplicationController
     end
 
     @resources = @resources.sort_by(&:created_at).reverse
+
+    @events = []
+    n_events = TeSS::Config.site.dig('home_page', 'upcoming_events')
+    return unless n_events
+
+    @events += Event.search_and_filter(
+      nil,
+      '',
+      { 'start' => "#{Date.tomorrow.beginning_of_day}/" },
+      sort_by: 'early',
+      per_page: n_events
+    ).results
   end
 
   def showcase

--- a/app/views/static/home.html.erb
+++ b/app/views/static/home.html.erb
@@ -50,3 +50,5 @@
 <%= render partial: 'static/home/faq' if TeSS::Config.site.dig('home_page', 'faq')&.any? %>
 
 <%= render partial: 'static/home/promo_blocks' if TeSS::Config.site.dig('home_page', 'promo_blocks') %>
+
+<%= render partial: 'static/home/upcoming_events' if TeSS::Config.site.dig('home_page', 'upcoming_events')&.positive? %>

--- a/app/views/static/home.html.erb
+++ b/app/views/static/home.html.erb
@@ -51,4 +51,4 @@
 
 <%= render partial: 'static/home/promo_blocks' if TeSS::Config.site.dig('home_page', 'promo_blocks') %>
 
-<%= render partial: 'static/home/upcoming_events' if TeSS::Config.site.dig('home_page', 'upcoming_events')&.positive? %>
+<%= render partial: 'static/home/upcoming_events' if @events.present? %>

--- a/app/views/static/home/_upcoming_events.html.erb
+++ b/app/views/static/home/_upcoming_events.html.erb
@@ -1,0 +1,13 @@
+<% return if @events.none? %>
+
+<% cache(['home', 'upcoming_events', @events]) do %>
+  <section id="upcoming_events">
+    <div class="tab-content">
+      <h2 class="text-center"><%= 'Upcoming events' %></h2>
+      <ul class="tab-pane fade in active">
+        <%= render partial: 'common/masonry_grid', locals: { objects: @events } %>
+      </ul>
+    </div>
+  </section>
+<% end %>
+

--- a/app/views/static/home/_upcoming_events.html.erb
+++ b/app/views/static/home/_upcoming_events.html.erb
@@ -1,5 +1,3 @@
-<% return if @events.none? %>
-
 <% cache(['home', 'upcoming_events', @events]) do %>
   <section id="upcoming_events">
     <div class="tab-content">

--- a/config/tess.example.yml
+++ b/config/tess.example.yml
@@ -38,6 +38,7 @@ default: &default
       featured_providers: # e.g. [123, 5, 10, 1]
       faq: # [who, how, why, embed, subscribe] # Questions/answers in config/en.yml: home > faq. Use empty array to hide section
       promo_blocks: false
+      upcoming_events: # Number of events on home page. Leave blank to turn off
     # The order in which the tabs appear (if feature enabled)
     tab_order: ['about', 'events', 'materials', 'elearning_materials', 'workflows', 'collections', 'trainers', 'content_providers', 'nodes']
     # The tabs that should be collapsed under the "Directory" tab. Can be left blank to hide it.

--- a/test/controllers/static_controller_test.rb
+++ b/test/controllers/static_controller_test.rb
@@ -106,7 +106,7 @@ class StaticControllerTest < ActionController::TestCase
       assert_select 'ul#promo-blocks', count: 0
     end
 
-    site_settings['home_page']['faq'] = ['who', 'why']
+    site_settings['home_page']['faq'] = %w[who why]
     with_settings({ site: site_settings }) do
       get :home
       assert_select 'section#catalogue', count: 1
@@ -136,7 +136,7 @@ class StaticControllerTest < ActionController::TestCase
                  'trainers': true,
                  'nodes': true }
 
-    with_settings(feature: features, site: { tab_order: ['materials', 'events'], directory_tabs: [] }) do
+    with_settings(feature: features, site: { tab_order: %w[materials events], directory_tabs: [] }) do
       get :home
       assert_select 'ul.nav.navbar-nav' do
         assert_select 'li:nth-child(1) a[href=?]', materials_path
@@ -152,7 +152,7 @@ class StaticControllerTest < ActionController::TestCase
       end
     end
 
-    with_settings(feature: features, site: { tab_order: ['content_providers', 'about', 'materials', 'trainers'],
+    with_settings(feature: features, site: { tab_order: %w[content_providers about materials trainers],
                                              directory_tabs: [] }) do
       get :home
 
@@ -170,8 +170,8 @@ class StaticControllerTest < ActionController::TestCase
       end
     end
 
-    with_settings(feature: features, site: { tab_order: ['content_providers', 'about', 'materials', 'trainers'],
-                                             directory_tabs: ['about', 'materials'] }) do
+    with_settings(feature: features, site: { tab_order: %w[content_providers about materials trainers],
+                                             directory_tabs: %w[about materials] }) do
       get :home
 
       assert_select 'ul.nav.navbar-nav' do
@@ -210,6 +210,23 @@ class StaticControllerTest < ActionController::TestCase
       assert_select 'section#providers .item a[href=?]', content_provider_path(regular_provider)
       assert_select 'section#providers .item a[href=?]', content_provider_path(unverified_provider), count: 0
       assert_select 'section#providers .item a[href=?]', content_provider_path(another_provider)
+    end
+  end
+
+  test 'should show upcoming events' do
+    my_events = [events(:one), events(:two)]
+    my_events.each do |e|
+      e.start = Time.zone.tomorrow
+      e.end = Time.zone.tomorrow + 1.day
+      e.save!
+    end
+    Event.stub(:search_and_filter, MockSearch.new(my_events)) do
+      with_settings({ site: { home_page: { upcoming_events: 5 } } }) do
+        get :home
+        assert_select 'section#upcoming_events', count: 1
+        assert_select 'section#upcoming_events h2', count: 1
+        assert_select 'section#upcoming_events ul', count: 2
+      end
     end
   end
 end


### PR DESCRIPTION
**Summary of changes**
Add option to show number of upcoming events on home page.
 
**Screenshots**

(Paste or upload any relevant screenshots)

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
