### PR TITLE
Don't attempt to send confirmation emails for default & admin users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -145,10 +145,18 @@ class User < ApplicationRecord
   end
 
   def self.get_default_user
-    User.default_scoped.where(role_id: Role.fetch('default_user').id).first_or_create!(username: 'default_user',
-                                                                   email: TeSS::Config.contact_email,
-                                                                   password: SecureRandom.base64,
-                                                                   processing_consent: '1')
+    User.default_scoped.where(role_id: Role.fetch('default_user').id).first || create_default_user
+  end
+
+  def self.create_default_user
+    u = User.new(role_id: Role.fetch('default_user').id,
+             username: 'default_user',
+             email: TeSS::Config.contact_email,
+             password: SecureRandom.base64,
+             processing_consent: '1')
+    u.skip_confirmation!
+    u.save!
+    u
   end
 
   def name

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,7 +19,10 @@ Node.load_from_hash(hash, verbose: false)
 if ENV["ADMIN_USERNAME"]
   puts "\nSeeding admin user"
   u = User.find_or_initialize_by(username: ENV["ADMIN_USERNAME"], role: Role.find_by_name('admin'))
-  u.update!(email: ENV["ADMIN_EMAIL"], password: ENV["ADMIN_PASSWORD"], processing_consent: "1") unless u.persisted?
+  unless u.persisted?
+    u.skip_confirmation!
+    u.update!(email: ENV["ADMIN_EMAIL"], password: ENV["ADMIN_PASSWORD"], processing_consent: "1")
+  end
 end
 
 puts "Done"

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -2,6 +2,8 @@ require 'test_helper'
 require 'ostruct'
 
 class UserTest < ActiveSupport::TestCase
+  include ActionMailer::TestHelper
+
   setup do
     mock_images
     @user_data = users(:regular_user)
@@ -416,5 +418,19 @@ class UserTest < ActiveSupport::TestCase
     assert user.save
     assert_equal 'space', user.username
     assert_equal 'new-user@example.com', user.email
+  end
+
+  test 'should not send confirmation email when creating default user' do
+    User.get_default_user.update!(role_id: Role.approved.id,
+                                  username: 'default_user2',
+                                  email: 'defaultuser2@example.com')
+
+    assert_no_enqueued_emails do
+      with_settings(force_user_confirmation: true) do
+        assert_difference('User.count', 1) do
+          User.create_default_user
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
**Summary of changes**

- Skips sending of confirmation emails when creating default user and admin user (in seeds).

**Motivation and context**

Can cause a crash during seeding process in production if `sendmail` not installed and email not configured.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
