### PR TITLE
Add dead URL checking task to the schedule

### DIFF
--- a/config/schedule.example.yml
+++ b/config/schedule.example.yml
@@ -11,3 +11,6 @@ ingestions:
 autocomplete_suggestions:
   every: tuesday
   at: 5am
+dead_link_check:
+  every: day
+  at: 6am

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -51,3 +51,13 @@ else
     rake "tess:rebuild_autocomplete_suggestions"
   end
 end
+
+if !schedules['dead_link_check'].nil?
+  every :"#{schedules['dead_link_check']['every']}", at: "#{schedules['dead_link_check']['at']}" do
+    rake "tess:check_resource_urls"
+  end
+else
+  every :day, at: '6am' do
+    rake "tess:check_resource_urls"
+  end
+end

--- a/lib/tasks/check_urls.rake
+++ b/lib/tasks/check_urls.rake
@@ -17,7 +17,7 @@ namespace :tess do
 
   desc 'Check event and material URLs for dead links'
   task check_resource_urls: :environment do
-    #check_materials
+    check_materials
     check_events
   end
 end


### PR DESCRIPTION
**Summary of changes**

- Adds a single rake task for checking event & material URLs
- Adds this task to the list of scheduled tasks
- Change logging to only report failing links

**Motivation and context**

Currently in production we are running this task via an external script, but it makes sense to be part of the regular set of scheduled TeSS tasks.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
