### PR TITLE
Event RSS tweaks

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -74,11 +74,15 @@ module EventsHelper
       events.each do |event|
         maker.items.new_item do |item|
           # required fields
-          item.title = [event.title, event.organizer.presence].compact.join(' - ')
+          item.title = event.title
           item.link = event_url(event)
 
           # optional fields
-          item.description = event.description
+          description = ''
+          description += (neatly_printed_date_range(event.start, event.end) + "\n\n") if event.start.present?
+          description += (event.description + "\n\n") if event.description.present?
+          description += event.organizer if event.organizer.present?
+          item.description = description.to_s
 
           # we should think about our RSS feed updating rules. If a line of the event description
           # changes, do we repost it? I don't think so.

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -756,6 +756,14 @@ class EventsControllerTest < ActionController::TestCase
     # find the one which will be first
     assert_equal Event.count, rss_events.items.count
     assert Event.friendly.find(rss_events.items.first.link.split('/').last.strip)
+
+    event = rss_events.items.detect { |i| i.link == event_url(events(:event_with_external_resource)) }
+    assert_not_nil event
+    assert_equal 'External Resource Event', event.title
+    description = event.description
+    assert_includes description, '12 December 2016 @ 10:00 - 12:00'
+    assert_includes description, 'this is my material'
+    assert_includes description, 'AnOrganizer'
   end
 
   test 'should include parameters in RSS file' do


### PR DESCRIPTION
**Summary of changes**

- Removes organizer from RSS item title
- Adds organizer and event date to RSS item description

**Motivation and context**

- #941 
- #942

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
