### PR TITLE
Fix misnamed learning path activity template

### DIFF
--- a/app/views/public_activity/learning_path/_add_topic.html.erb
+++ b/app/views/public_activity/learning_path/_add_topic.html.erb
@@ -1,12 +1,10 @@
-<% type = activity.parameters[:resource_type].constantize %>
-
 <i class="fa fa-pencil-square-o"></i>
 
 <% if activity.owner %>
     <%= link_to activity.owner.username, activity.owner %>
 <% end %>
 
-added <%= type.model_name.human.downcase %>
+added topic
 <%= link_to activity.parameters[:topic_title], learning_path_topic_path(activity.parameters[:topic_id]) %>
 to
 <%= link_to activity.trackable.title, activity.trackable %>


### PR DESCRIPTION
**Summary of changes**

- As in title

**Motivation and context**

Ajax to load activity log on learning path page would throw 500. Error caught via sentry from dev server
 
**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
