### PR TITLE
Add method to delete user & resources (without re-assigning them)

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -364,6 +364,16 @@ class User < ApplicationRecord
     end
   end
 
+  def purge
+    User.transaction do
+      CREATED_RESOURCE_TYPES.each do |type|
+        send(type).find_each { |x| x.destroy }
+      end
+
+      destroy
+    end
+  end
+
   protected
 
   def reassign_resources(new_owner = User.get_default_user)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -442,4 +442,37 @@ class UserTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test 'purges user and all resources' do
+    user = users(:regular_user)
+    event = events(:one)
+    material = materials(:good_material)
+    workflow = workflows(:one)
+    content_provider = content_providers(:goblet)
+    source = sources(:unapproved_source)
+    collection = collections(:one)
+    node = nodes(:good)
+
+    assert_equal user, event.user
+    assert_equal user, material.user
+    assert_equal user, workflow.user
+    assert_equal user, content_provider.user
+    assert_equal user, source.user
+    assert_equal user, collection.user
+    assert_equal user, node.user
+
+    assert_difference('User.count', -1) do
+      assert_difference('Profile.count', -1) do
+        assert user.purge
+      end
+    end
+
+    assert_raise(ActiveRecord::RecordNotFound) { event.reload }
+    assert_raise(ActiveRecord::RecordNotFound) { material.reload }
+    assert_raise(ActiveRecord::RecordNotFound) { workflow.reload }
+    assert_raise(ActiveRecord::RecordNotFound) { content_provider.reload }
+    assert_raise(ActiveRecord::RecordNotFound) { source.reload }
+    assert_raise(ActiveRecord::RecordNotFound) { collection.reload }
+    assert_raise(ActiveRecord::RecordNotFound) { node.reload }
+  end
 end


### PR DESCRIPTION
**Summary of changes**

- Adds `User#purge` to delete user + resources.

**Motivation and context**

Default deletion moves resources to the default user, which can be undesirable a times, for example when deleting spammers.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
