### PR TITLE
Ensure ical ingestor results can be deserialized

### DIFF
--- a/lib/ingestors/ical_ingestor.rb
+++ b/lib/ingestors/ical_ingestor.rb
@@ -79,10 +79,10 @@ module Ingestors
         # puts "\n\ncalevent.description = #{calevent.description}"
         # puts "\n\n...        converted = #{event.description}"
 
-        event.end = calevent.dtend
+        event.end = calevent.dtend&.to_time
         unless calevent.dtstart.nil?
           dtstart = calevent.dtstart
-          event.start = dtstart
+          event.start = dtstart&.to_time
           tzid = dtstart.ical_params['tzid']
           event.timezone = tzid.first.to_s if !tzid.nil? and tzid.size > 0
         end


### PR DESCRIPTION
**Summary of changes**

- Converts Ical date objects to regular Time objects that are in the default list of classes allowed to be serialized to YAML

**Motivation and context**

- #986

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
