### PR TITLE
Replace workflows catalogue block with learning paths

### DIFF
--- a/app/assets/images/modern/icons/learning-paths-icon.svg
+++ b/app/assets/images/modern/icons/learning-paths-icon.svg
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="learning-paths-icon.svg"
+   id="svg1243"
+   version="1.1"
+   fill="none"
+   viewBox="0 0 68 68"
+   height="68"
+   width="68">
+  <metadata
+     id="metadata1247">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     inkscape:current-layer="g847"
+     inkscape:window-maximized="1"
+     inkscape:window-y="0"
+     inkscape:window-x="0"
+     inkscape:cy="24.610815"
+     inkscape:cx="41.003293"
+     inkscape:zoom="10.887365"
+     showgrid="false"
+     id="namedview1245"
+     inkscape:window-height="1247"
+     inkscape:window-width="2560"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <defs
+     id="defs1241">
+    <inkscape:path-effect
+       effect="perspective-envelope"
+       up_left_point="14.496396,7.6311181"
+       up_right_point="58.193068,7.6311181"
+       down_left_point="-1.5543458,71.803797"
+       down_right_point="74.24381,71.803797"
+       id="path-effect849"
+       is_visible="true"
+       deform_type="perspective"
+       horizontal_mirror="false"
+       vertical_mirror="true"
+       overflow_perspective="false" />
+    <inkscape:path-effect
+       effect="perspective-envelope"
+       up_left_point="10.638713,5.2430288"
+       up_right_point="54.335385,5.2430288"
+       down_left_point="-0.109436,54.986059"
+       down_right_point="65.083534,54.986059"
+       id="path-effect1402"
+       is_visible="false"
+       deform_type="perspective"
+       horizontal_mirror="false"
+       vertical_mirror="true"
+       overflow_perspective="false" />
+    <inkscape:path-effect
+       effect="perspective-envelope"
+       up_left_point="9.8388718,1.5690452"
+       up_right_point="56.815324,1.5690452"
+       down_left_point="9.8388718,64.084248"
+       down_right_point="56.815324,64.084248"
+       id="path-effect1377"
+       is_visible="true"
+       deform_type="perspective"
+       horizontal_mirror="false"
+       vertical_mirror="true"
+       overflow_perspective="false" />
+    <inkscape:path-effect
+       effect="perspective-envelope"
+       up_left_point="7.91003,1.8445935"
+       up_right_point="54.417967,1.8445935"
+       down_left_point="7.91003,63.808699"
+       down_right_point="54.417967,63.808699"
+       id="path-effect1345"
+       is_visible="true"
+       deform_type="perspective"
+       horizontal_mirror="false"
+       vertical_mirror="true"
+       overflow_perspective="false" />
+    <clipPath
+       id="clip0_617_222">
+      <rect
+         width="68"
+         height="68"
+         fill="white"
+         id="rect1235" />
+    </clipPath>
+    <clipPath
+       id="clip1_617_222">
+      <rect
+         width="66"
+         height="66"
+         fill="white"
+         transform="translate(-1 -1)"
+         id="rect1238" />
+    </clipPath>
+  </defs>
+  <g
+     id="g847"
+     inkscape:path-effect="#path-effect849"
+     transform="translate(1.1940447,-5.4191258)">
+    <path
+       style="fill:#047eaa;stroke-width:0.83759344"
+       inkscape:connector-curvature="0"
+       id="path1213"
+       d="m 56.945119,49.001596 c 4.901508,0 8.295186,-2.531228 7.610881,-5.519692 -0.652663,-2.850277 -4.806515,-5.065781 -9.304949,-5.065781 -4.498298,0 -7.94316,2.215504 -7.683523,5.065781 0.272225,2.988464 4.476231,5.519692 9.377591,5.519692 z"
+       inkscape:original-d="m 50.324309,52.296038 c 3.3262,0 6.0225,-1.891695 6.0225,-4.225162 0,-2.333538 -2.6963,-4.225162 -6.0225,-4.225162 -3.3261,0 -6.0225,1.891624 -6.0225,4.225162 0,2.333467 2.6964,4.225162 6.0225,4.225162 z" />
+    <path
+       style="fill:#047eaa;stroke-width:0.83759344"
+       inkscape:connector-curvature="0"
+       id="path1219"
+       d="m 31.034141,13.28648 c 3.541545,0 6.396669,-1.328705 6.377861,-2.916346 -0.01817,-1.5335894 -2.728748,-2.7390159 -6.054948,-2.7390159 -3.3261,0 -6.174436,1.2054265 -6.367736,2.7390159 -0.200112,1.587641 2.503384,2.916346 6.044823,2.916346 z"
+       inkscape:original-d="m 31.357054,16.081441 c 3.3262,0 6.0225,-1.891673 6.0225,-4.225161 0,-2.3334892 -2.6963,-4.2251619 -6.0225,-4.2251619 -3.3261,0 -6.0225,1.8916727 -6.0225,4.2251619 0,2.333488 2.6964,4.225161 6.0225,4.225161 z" />
+    <path
+       style="fill:#047eaa;stroke-width:0.83759344"
+       inkscape:connector-curvature="0"
+       id="path1223"
+       d="m 10.246282,71.803797 c 5.769599,0 10.80793,-3.495252 11.230971,-7.590776 0.400276,-3.875117 -3.521753,-6.866526 -8.740862,-6.866526 -5.2192657,0 -10.1716112,2.991409 -11.1062271,6.866526 -0.9877744,4.095524 2.8463468,7.590776 8.6161181,7.590776 z"
+       inkscape:original-d="m 21.299308,66.488002 c 3.3261,0 6.0225,-1.891693 6.0225,-4.225161 0,-2.333538 -2.6964,-4.225162 -6.0225,-4.225162 -3.3262,0 -6.0225,1.891624 -6.0225,4.225162 0,2.333468 2.6963,4.225161 6.0225,4.225161 z" />
+    <path
+       style="fill:#047eaa;stroke-width:0.83759344"
+       inkscape:connector-curvature="0"
+       id="path1227"
+       d="m 15.697859,34.241056 c 4.339453,0 8.080287,-1.988485 8.345065,-4.347769 0.253858,-2.261982 -2.807049,-4.028217 -6.827561,-4.028217 -4.020393,0 -7.7213736,1.766235 -8.287136,4.028217 -0.5900995,2.359284 2.430307,4.347769 6.769632,4.347769 z"
+       inkscape:original-d="m 20.518867,40.081095 c 3.326199,0 6.022499,-1.891693 6.022499,-4.225161 0,-2.333538 -2.6963,-4.225161 -6.022499,-4.225161 -3.3261,0 -6.022471,1.891623 -6.022471,4.225161 0,2.333468 2.696371,4.225161 6.022471,4.225161 z" />
+    <path
+       style="fill:#047eaa;stroke-width:0.83759344"
+       inkscape:connector-curvature="0"
+       id="path1219-3"
+       d="m 55.365296,25.264704 c 3.997653,0 6.815581,-1.689876 6.312575,-3.700951 -0.483794,-1.934263 -3.882535,-3.448904 -7.607935,-3.448904 -3.725288,0 -6.575317,1.514641 -6.358239,3.448904 0.225699,2.011075 3.656066,3.700951 7.653599,3.700951 z"
+       inkscape:original-d="m 52.170568,30.973291 c 3.3262,0 6.0225,-1.891673 6.0225,-4.225162 0,-2.333488 -2.6963,-4.225161 -6.0225,-4.225161 -3.3261,0 -6.0225,1.891673 -6.0225,4.225161 0,2.333489 2.6964,4.225162 6.0225,4.225162 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path1367"
+       d="m 32.462873,8.8833998 c 0,0 -2.851394,2.4453482 -2.851394,2.4453482 0,0 19.306907,9.377049 19.306907,9.377049 0,0 -33.155286,6.304851 -33.155286,6.304851 0,0 -1.21223,4.164714 -1.21223,4.164714 0,0 34.637318,12.591697 34.637318,12.591697 0,0 -35.768493,14.240018 -35.768493,14.240018 0,0 1.823161,6.812483 1.823161,6.812483 0,0 43.815577,-18.403585 43.815577,-18.403585 0,0 -0.954288,-5.224157 -0.954288,-5.224157 0,0 -33.346962,-11.565529 -33.346962,-11.565529 0,0 31.374419,-6.212586 31.374419,-6.212586 0,0 0.205737,-3.413632 0.205737,-3.413632 0,0 -23.874466,-11.1166712 -23.874466,-11.1166712 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.35;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#047eaa;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.52285051;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       inkscape:original-d="m 32.517737,9.5952813 -2.632813,3.6796877 17.396484,12.449218 -27.78125,7.140625 -0.322265,4.271485 26.251953,11.162109 -23.625,10.164063 1.787109,4.154296 28.482422,-12.253906 -0.0098,-4.158203 -24.976562,-10.619141 26.015625,-6.6875 0.753906,-4.029296 z" />
+  </g>
+</svg>

--- a/app/views/learning_paths/index.html.erb
+++ b/app/views/learning_paths/index.html.erb
@@ -18,7 +18,7 @@
       <% end %>
       <% if policy(LearningPathTopic).create? %>
         <%= link_to learning_path_topics_path, class: 'btn btn-default' do %>
-          Topics
+          Manage topics
         <% end %>
       <% end %>
       <!-- Info -->

--- a/app/views/static/home/_catalogue_blocks.html.erb
+++ b/app/views/static/home/_catalogue_blocks.html.erb
@@ -1,4 +1,4 @@
-<% features = ['events', 'materials', 'workflows', 'trainers'].select { |f| TeSS::Config.feature[f] } %>
+<% features = ['events', 'materials', 'learning_paths', 'trainers'].select { |f| TeSS::Config.feature[f] } %>
 
 <section id="catalogue">
   <h2 class="text-center"><%= t('home.catalogue.title') %></h2>
@@ -8,7 +8,7 @@
       <li class="resource-type">
         <%= link_to polymorphic_path(feature), class: 'link-overlay' do %>
           <div class="resource-type-title">
-            <%= image_tag(asset_path("modern/icons/#{feature}-icon.svg"), alt: feature.titleize) %>
+            <%= image_tag(asset_path("modern/icons/#{feature.dasherize}-icon.svg"), alt: feature.titleize) %>
             <h3><%= t("features.#{feature}.long").titleize %></h3>
           </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -324,6 +324,7 @@ en:
       workflows: "Create training workflows to visualise learning steps and link to resources specific to your training needs."
       providers: "Browse training providers to discover training resources they offer and follow links to their materials and courses."
       trainers: "Browse a directory of trainers based on their skills and expertise."
+      learning_paths: "Follow organized pathways of training resources leading you towards specific learning objectives."
       events_count: "%{total_events} upcoming events, %{last_month_events} added last month"
     providers:
       title: Providers


### PR DESCRIPTION
**Summary of changes**

- Replaces the workflow block on the front page with one for learning paths (if enabled).

**Motivation and context**

We are promoting LPs over workflows
 
**Screenshots**

![image](https://github.com/ElixirTeSS/TeSS/assets/503373/13720340-3c29-4cd8-b1c4-15782860b4d0)

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
