### PR TITLE
Strip `.json` extension from URLs returned from API endpoints

### DIFF
--- a/app/views/collections/index.json.jbuilder
+++ b/app/views/collections/index.json.jbuilder
@@ -1,4 +1,4 @@
 json.array!(@collections) do |collection|
   json.extract! collection, :id, :title, :description, :image_url
-  json.url collection_url(collection, format: :json)
+  json.url collection_url(collection)
 end

--- a/app/views/content_providers/index.json.jbuilder
+++ b/app/views/content_providers/index.json.jbuilder
@@ -1,5 +1,5 @@
 json.array!(@content_providers) do |content_provider|
   json.extract! content_provider, :id, :id, :title, :image_url, :description,
                 :url, :created_at, :updated_at, :contact
-  json.url content_provider_url(content_provider, format: :json)
+  json.url content_provider_url(content_provider)
 end

--- a/app/views/learning_path_topics/index.json.jbuilder
+++ b/app/views/learning_path_topics/index.json.jbuilder
@@ -1,4 +1,4 @@
 json.array!(@learning_path_topics) do |learning_path_topic|
   json.extract! learning_path_topic, :id, :title, :description
-  json.url learning_path_topic_url(learning_path_topic, format: :json)
+  json.url learning_path_topic_url(learning_path_topic)
 end

--- a/app/views/materials/index.json.jbuilder
+++ b/app/views/materials/index.json.jbuilder
@@ -1,6 +1,6 @@
 json.array!(@materials) do |material|
   json.extract! material, :id, :title, :url, :description, :doi, :remote_updated_date, :remote_created_date
-  json.url material_url(material, format: :json)
+  json.url material_url(material)
 
   json.partial! 'common/ontology_terms', type: 'scientific_topics', resource: material
   json.partial! 'common/ontology_terms', type: 'operations', resource: material

--- a/app/views/nodes/index.json.jbuilder
+++ b/app/views/nodes/index.json.jbuilder
@@ -1,4 +1,4 @@
 json.array!(@nodes) do |node|
   json.extract! node, :id, :title, :description, :image_url, :events, :materials, :created_at, :updated_at
-  json.url node_url(node, format: :json)
+  json.url node_url(node)
 end

--- a/app/views/sources/index.json.jbuilder
+++ b/app/views/sources/index.json.jbuilder
@@ -1,5 +1,5 @@
 json.array!(@sources) do |source|
   json.extract! source, :content_provider, :created_at, :url,
                 :method, :enabled
-  json.url source_url(source, format: :json)
+  json.url source_url(source)
 end

--- a/app/views/users/_list.json.jbuilder
+++ b/app/views/users/_list.json.jbuilder
@@ -1,5 +1,5 @@
 json.array!(users) do |user|
   json.extract! user, :id, :username
   json.extract! user.profile, :firstname, :surname if user.profile
-  json.url user_url(user, format: :json)
+  json.url user_url(user)
 end

--- a/app/views/workflows/index.json.jbuilder
+++ b/app/views/workflows/index.json.jbuilder
@@ -1,6 +1,6 @@
 json.array!(@workflows) do |workflow|
   json.extract! workflow, :id, :title, :description, :user_id, :workflow_content
-  json.url workflow_url(workflow, format: :json)
+  json.url workflow_url(workflow)
 
   json.partial! 'common/ontology_terms', type: 'scientific_topics', resource: workflow
 end


### PR DESCRIPTION
**Summary of changes**

- Remove the `.json` extension from resource URLs in API responses

**Motivation and context**

Because these are used in various autocompleters (e.g. when adding a material to a collection), and can end up taking a web user to a JSON page.

API clients can get JSON using the `Accept` header.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
