### PR TITLE
Hide unverified user's content from other users

### DIFF
--- a/app/controllers/content_providers_controller.rb
+++ b/app/controllers/content_providers_controller.rb
@@ -15,6 +15,7 @@ class ContentProvidersController < ApplicationController
   end
 
   def show
+    authorize @content_provider
     respond_to do |format|
       format.html
       format.json

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -60,6 +60,7 @@ class EventsController < ApplicationController
   # GET /events/1.json
   # GET /events/1.ics
   def show
+    authorize @event
     @bioschemas = @event.to_bioschemas
     respond_to do |format|
       format.html

--- a/app/controllers/materials_controller.rb
+++ b/app/controllers/materials_controller.rb
@@ -28,6 +28,7 @@ class MaterialsController < ApplicationController
   # GET /materials/1
   # GET /materials/1.json
   def show
+    authorize @material
     @bioschemas = @material.to_bioschemas
     respond_to do |format|
       format.html

--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -23,6 +23,7 @@ class WorkflowsController < ApplicationController
   # GET /workflows/1
   # GET /workflows/1.json
   def show
+    authorize @workflow
     @skip_flash_messages_in_header = true # we will handle flash messages in the 'workflows' layout
     respond_to do |format|
       format.html { render layout: 'workflows' }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -682,4 +682,9 @@ module ApplicationHelper
     content_tag('div', t('warnings.archived', resource_type: resource.model_name.human.downcase),
                 class: 'alert alert-warning mb-4 archived-notice')
   end
+
+  def unverified_notice(resource)
+    content_tag('div', t('warnings.unverified', resource_type: resource.model_name.human.downcase),
+                class: 'alert alert-warning mb-4 unverified-notice')
+  end
 end

--- a/app/policies/collection_policy.rb
+++ b/app/policies/collection_policy.rb
@@ -5,7 +5,7 @@ class CollectionPolicy < ResourcePolicy
   end
 
   def show?
-    @record.public? || manage?
+    (!@record.from_unverified_or_rejected? && @record.public?) || manage?
   end
 
   def curate?

--- a/app/policies/resource_policy.rb
+++ b/app/policies/resource_policy.rb
@@ -1,6 +1,9 @@
 # A policy for general "resources" in TeSS. This includes things registered by the scraper and things created by users.
 
 class ResourcePolicy < ApplicationPolicy
+  def show?
+    !@record.from_unverified_or_rejected? || manage?
+  end
 
   def create?
     super && !@user.has_role?(:basic_user)

--- a/app/policies/workflow_policy.rb
+++ b/app/policies/workflow_policy.rb
@@ -5,7 +5,7 @@ class WorkflowPolicy < ResourcePolicy
   end
 
   def show?
-    @record.public? || manage?
+    (!@record.from_unverified_or_rejected? && @record.public?)  || manage?
   end
 
   class Scope < Scope

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -4,6 +4,7 @@
   </div>
 
   <div id="content">
+    <%= unverified_notice(@collection) if @collection.from_unverified_or_rejected? %>
     <div class="content-actions">
       <div class="content-manager-actions">
         <% if policy(@collection).manage? %>

--- a/app/views/content_providers/show.html.erb
+++ b/app/views/content_providers/show.html.erb
@@ -5,6 +5,8 @@
   </div>
 
   <div id="content">
+    <%= unverified_notice(@content_provider) if @content_provider.from_unverified_or_rejected? %>
+
     <div class="content-actions">
       <div class="content-viewer-actions">
         <%= external_link_button 'View home page', @content_provider.url if @content_provider.url.present? %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -10,6 +10,7 @@
     <div id="home" class="my-2">
       <div class="page-header">
         <%= broken_link_notice(@event) if @event.failing? %>
+        <%= unverified_notice(@event) if @event.from_unverified_or_rejected? %>
 
         <% if @event.event_types.any? %>
           <% @event.event_types.each do |t| %>

--- a/app/views/materials/show.html.erb
+++ b/app/views/materials/show.html.erb
@@ -10,6 +10,7 @@
       <div>
         <%= broken_link_notice(@material) if @material.failing? %>
         <%= archived_notice(@material) if @material.archived? %>
+        <%= unverified_notice(@material) if @material.from_unverified_or_rejected? %>
 
         <!-- Field: title -->
         <div class="sub-heading"><%= display_attribute_no_label(@material, :resource_type) { |values| values.join(', ') } %></div>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -53,8 +53,9 @@
                       label: 'Training Experience', prompt: 'Select a level of experience...',
                       input_html: { title: t('profile.hints.experience') } %>
 
-          <%= f.dropdown :language, options: language_options_for_select,
-                         label: 'Languages Spoken', model_name: 'user[profile_attributes]',
+          <%= f.input :language, options: language_options_for_select,
+                         label: 'Languages Spoken', model_name: 'user[profile_attributes]', as: :select,
+             input_html: { class: 'js-select2' },
                          errors: @user.profile.errors[:language], title: t('profile.hints.language') %>
 
           <%= f.multi_input :expertise_academic, label: 'Academic expertise',

--- a/app/views/workflows/show.html.erb
+++ b/app/views/workflows/show.html.erb
@@ -1,5 +1,6 @@
 <div class="wrapper collapsing-wrapper">
   <div id="content">
+    <%= unverified_notice(@workflow) if @workflow.from_unverified_or_rejected? %>
     <div class="content-actions">
       <div class="content-viewer-actions">
         <%= render partial: 'common/identifiers_dot_org_button', locals: { resource: @workflow } if TeSS::Config.identifiers_prefix %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -614,6 +614,7 @@ en:
   warnings:
     link_broken: TeSS has been unable to access this %{resource_type}'s URL since %{fail_date} - the page may have been moved.
     archived: This %{resource_type} has been archived, its content may no longer be relevant.
+    unverified: This %{resource_type} will not be publicly visible until your registration has been approved by an administrator.
   footer:
     eu_funding: >
       TeSS has received funding from the European Union’s Horizon 2020 research and innovation programme under grant agreement No. <a href="https://cordis.europa.eu/project/rcn/198519_en.html", target="_blank">676559</a>.

--- a/test/controllers/content_providers_controller_test.rb
+++ b/test/controllers/content_providers_controller_test.rb
@@ -550,4 +550,36 @@ class ContentProvidersControllerTest < ActionController::TestCase
       assert_select '.masonry-brick.media-item.long', count: 0
     end
   end
+
+  test 'should show unverified users content provider to themselves' do
+    sign_in users(:unverified_user)
+    content_provider = users(:unverified_user).content_providers.create!(title: 'Hello', description: 'World',
+                                                                         url: 'https://example.com/content_provider')
+
+    get :show, params: { id: content_provider }
+
+    assert_response :success
+    assert_select '.unverified-notice',
+                  text: 'This content provider will not be publicly visible until your registration has been approved by an administrator.'
+  end
+
+  test 'should show unverified users content provider to admin' do
+    content_provider = users(:unverified_user).content_providers.create!(title: 'Hello', description: 'World',
+                                                                         url: 'https://eexample.com/content_provider')
+    sign_in users(:admin)
+
+    get :show, params: { id: content_provider }
+
+    assert_response :success
+    assert_select '.unverified-notice',
+                  text: 'This content provider will not be publicly visible until your registration has been approved by an administrator.'
+  end
+
+  test 'should not show unverified users content provider anon user' do
+    content_provider = users(:unverified_user).content_providers.create!(title: 'Hello', description: 'World',
+                                                                         url: 'https://example.com/content_provider')
+
+    get :show, params: { id: content_provider }
+    assert_response :forbidden
+  end
 end

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -1513,4 +1513,36 @@ class EventsControllerTest < ActionController::TestCase
       assert_select '.small-avatar', count: 0
     end
   end
+
+  test 'should show unverified users event to themselves' do
+    sign_in users(:unverified_user)
+    event = users(:unverified_user).events.create!(title: 'Hello', description: 'World',
+                                                   url: 'https://example.com/event')
+
+    get :show, params: { id: event }
+
+    assert_response :success
+    assert_select '.unverified-notice',
+                  text: 'This event will not be publicly visible until your registration has been approved by an administrator.'
+  end
+
+  test 'should show unverified users event to admin' do
+    event = users(:unverified_user).events.create!(title: 'Hello', description: 'World',
+                                                   url: 'https://eexample.com/event')
+    sign_in users(:admin)
+
+    get :show, params: { id: event }
+
+    assert_response :success
+    assert_select '.unverified-notice',
+                  text: 'This event will not be publicly visible until your registration has been approved by an administrator.'
+  end
+
+  test 'should not show unverified users event anon user' do
+    event = users(:unverified_user).events.create!(title: 'Hello', description: 'World',
+                                                   url: 'https://example.com/event')
+
+    get :show, params: { id: event }
+    assert_response :forbidden
+  end
 end

--- a/test/controllers/materials_controller_test.rb
+++ b/test/controllers/materials_controller_test.rb
@@ -1427,4 +1427,45 @@ class MaterialsControllerTest < ActionController::TestCase
       end
     end
   end
+
+  test 'should show unverified users material to themselves' do
+    sign_in users(:unverified_user)
+    material = users(:unverified_user).materials.create!(description: @material.description,
+                                              title: @material.title, url: 'http://example.com/dodgy-event',
+                                              doi: 'https://doi.org/10.10067/SEA.2019.22', status: 'active',
+                                              licence: 'CC-BY-4.0', contact: 'default contact',
+                                              keywords: %w{ dodgy event unverified user })
+
+    get :show, params: { id: material }
+
+    assert_response :success
+    assert_select '.unverified-notice',
+                  text: 'This material will not be publicly visible until your registration has been approved by an administrator.'
+  end
+
+  test 'should show unverified users material to admin' do
+    material = users(:unverified_user).materials.create!(description: @material.description,
+                                              title: @material.title, url: 'http://example.com/dodgy-event',
+                                              doi: 'https://doi.org/10.10067/SEA.2019.22', status: 'active',
+                                              licence: 'CC-BY-4.0', contact: 'default contact',
+                                              keywords: %w{ dodgy event unverified user })
+    sign_in users(:admin)
+
+    get :show, params: { id: material }
+
+    assert_response :success
+    assert_select '.unverified-notice',
+                  text: 'This material will not be publicly visible until your registration has been approved by an administrator.'
+  end
+
+  test 'should not show unverified users material anon user' do
+    material = users(:unverified_user).materials.create!(description: @material.description,
+                                              title: @material.title, url: 'http://example.com/dodgy-event',
+                                              doi: 'https://doi.org/10.10067/SEA.2019.22', status: 'active',
+                                              licence: 'CC-BY-4.0', contact: 'default contact',
+                                              keywords: %w{ dodgy event unverified user })
+
+    get :show, params: { id: material }
+    assert_response :forbidden
+  end
 end

--- a/test/controllers/workflows_controller_test.rb
+++ b/test/controllers/workflows_controller_test.rb
@@ -255,4 +255,33 @@ class WorkflowsControllerTest < ActionController::TestCase
     assert_select '.identifiers-button'
     assert_select '#identifiers-link[value=?]', "http://example.com/identifiers/banana:w#{@workflow.id}"
   end
+
+  test 'should show unverified users workflow to themselves' do
+    sign_in users(:unverified_user)
+    workflow = users(:unverified_user).workflows.create!(title: 'Hello', description: 'World', public: true)
+
+    get :show, params: { id: workflow }
+
+    assert_response :success
+    assert_select '.unverified-notice',
+                  text: 'This workflow will not be publicly visible until your registration has been approved by an administrator.'
+  end
+
+  test 'should show unverified users workflow to admin' do
+    workflow = users(:unverified_user).workflows.create!(title: 'Hello', description: 'World', public: true)
+    sign_in users(:admin)
+
+    get :show, params: { id: workflow }
+
+    assert_response :success
+    assert_select '.unverified-notice',
+                  text: 'This workflow will not be publicly visible until your registration has been approved by an administrator.'
+  end
+
+  test 'should not show unverified users workflow anon user' do
+    workflow = users(:unverified_user).workflows.create!(title: 'Hello', description: 'World', public: true)
+
+    get :show, params: { id: workflow }
+    assert_response :forbidden
+  end
 end


### PR DESCRIPTION
**Summary of changes**

- If a user is a basic user, or unverified user, don't show their content ever (previously it was hidden from indexes, but accessible directly).
- Displays a notice to the user explaining only they can see it.
- Admins/curators can still see this content.

**Motivation and context**

Spam users

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
