### PR TITLE
Switch back to cookie_store for sessions

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,6 +1,3 @@
 # Be sure to restart your server when you modify this file.
-
-#Rails.application.config.session_store :cookie_store, key: '_tess_sessions'
-Rails.application.config.session_store :active_record_store, key: '_tess_sessions', secure: Rails.env.production?
-
-
+opts = Rails.env.production? ? { same_site: :strict, secure: true } : {}
+Rails.application.config.session_store :cookie_store, **opts

--- a/db/migrate/20240702175333_drop_sessions.rb
+++ b/db/migrate/20240702175333_drop_sessions.rb
@@ -1,0 +1,16 @@
+class DropSessions < ActiveRecord::Migration[7.0]
+  def up
+    drop_table :sessions
+  end
+
+  def down
+    create_table :sessions do |t|
+      t.string :session_id, null: false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id, unique: true
+    add_index :sessions, :updated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -451,15 +451,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_18_100022) do
     t.string "title"
   end
 
-  create_table "sessions", force: :cascade do |t|
-    t.string "session_id", null: false
-    t.text "data"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
-    t.index ["updated_at"], name: "index_sessions_on_updated_at"
-  end
-
   create_table "sources", force: :cascade do |t|
     t.bigint "content_provider_id"
     t.bigint "user_id"


### PR DESCRIPTION
**Summary of changes**

- Store session data in encrypted cookies instead of a database table.

**Motivation and context**

The `sessions` table in production accounts for 90%+ of the database size even when pruned of stale sessions. This table is written to every time an anonymous user visits TeSS. It's not clear why we moved away from the default cookie store implementation in the first place as we are not storing much data in the session.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
