### PR TITLE
Handle `language` being blank (not just nil)

### DIFF
--- a/app/models/concerns/has_language.rb
+++ b/app/models/concerns/has_language.rb
@@ -3,8 +3,7 @@ module HasLanguage
   extend ActiveSupport::Concern
 
   included do
-    validates :language, controlled_vocabulary: { dictionary: 'LanguageDictionary',
-                                                  allow_nil: true }
+    validates :language, controlled_vocabulary: { dictionary: 'LanguageDictionary', allow_blank: true }
 
     if TeSS::Config.solr_enabled
       # :nocov:

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -52,7 +52,7 @@
 
   <!-- Field: Language -->
   <%= f.input :language, collection: LanguageDictionary.instance.options_for_select,
-      prompt: t('events.prompts.language'), input_html: { title: t('events.hints.language') } %>
+      prompt: t('events.prompts.language'), include_blank: true, input_html: { title: t('events.hints.language') } %>
 
   <!-- Field: Prerequisites -->
   <%= f.input :prerequisites, as: :markdown_area, input_html: { rows: '3', title: t('events.hints.prerequisites') } %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -63,12 +63,7 @@
         </p>
         <%= display_attribute(@event, :timezone) %>
         <%= display_attribute(@event, :duration) %>
-        <% if @event.language %>
-          <%= display_attribute(@event, :language) do |value|
-                render_language_name(value)
-              end %>
-        <% end %>
-
+        <%= display_attribute(@event, :language) { |value| render_language_name(value) } %>
         <!-- Field: description -->
         <div class="description">
           <%= google_maps_javascript_api_tag(@event) if @event.show_map? %>

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -1545,4 +1545,28 @@ class EventsControllerTest < ActionController::TestCase
     get :show, params: { id: event }
     assert_response :forbidden
   end
+
+  test 'should create event without language specified' do
+    sign_in users(:regular_user)
+    assert_difference('Event.count', 1) do
+      post :create, params: { event: { description: @event.description, title: @event.title, url: @event.url,
+                                       language: '' } }
+    end
+    assert_redirected_to event_path(assigns(:event))
+    refute assigns(:event).language.present?
+  end
+
+  test 'should display language of instruction' do
+    get :show, params: { id: events(:one) }
+    assert_response :success
+    assert_select 'strong', text: 'Language of instruction:'
+  end
+
+  test 'should not display language of instruction if not specified' do
+    event = users(:regular_user).events.create!(title: 'No language', url: 'https://example.com/nolang', language: '')
+
+    get :show, params: { id: event }
+    assert_response :success
+    assert_select 'strong', text: 'Language of instruction:', count: 0
+  end
 end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -411,6 +411,10 @@ class EventTest < ActiveSupport::TestCase
     event.language = nil
     assert event.valid?
 
+    # Okay if blank
+    event.language = ''
+    assert event.valid?
+
     # Not okay if not a known ISO-639-2 code
     event.language = 'yo'
     refute event.valid?


### PR DESCRIPTION
**Summary of changes**

- Change Event language validation to accept empty string
- Allow language to be unset when editing an event

**Motivation and context**

When creating an event through the UI, if you don't select a language from the drop down, the parameter is passed as `""`, which causes validation to fail.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
