### PR TITLE
Change cookie SameSite setting to "Lax"

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
-opts = Rails.env.production? ? { same_site: :strict, secure: true } : {}
+opts = Rails.env.production? ? { same_site: :lax, secure: true } : {}
 Rails.application.config.session_store :cookie_store, **opts


### PR DESCRIPTION
**Summary of changes**

- Switch SameSite attribute from "strict" to "lax"

**Motivation and context**

LS-Login was broken, because with a `SameSite=strict` cookie, cookies are not sent immediately following a redirect, so Rails creates a new session for the user which does not have the stored OAuth2 state or nonce, causing verification to fail.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
