### PR TITLE
Learning Path curator role

### DIFF
--- a/app/policies/learning_path_policy.rb
+++ b/app/policies/learning_path_policy.rb
@@ -9,11 +9,11 @@ class LearningPathPolicy < ScrapedResourcePolicy
   end
 
   def manage?
-    curators_and_admin
+    curators_and_admin || @user&.has_role?(:learning_path_curator)
   end
 
   def create?
-    curators_and_admin
+    manage?
   end
 
   class Scope < Scope

--- a/config/data/roles.yml
+++ b/config/data/roles.yml
@@ -14,3 +14,5 @@ basic_user: # Cannot create content
   title: Basic user
 unverified_user: # Content requires approval before being visible
   title: New user
+learning_path_curator:
+  title: Learning path curator

--- a/test/controllers/learning_paths_controller_test.rb
+++ b/test/controllers/learning_paths_controller_test.rb
@@ -63,6 +63,10 @@ class LearningPathsControllerTest < ActionController::TestCase
     get :new
     assert_response :success
 
+    sign_in users(:learning_path_curator)
+    get :new
+    assert_response :success
+
     sign_in users(:admin)
     get :new
     assert_response :success
@@ -78,6 +82,12 @@ class LearningPathsControllerTest < ActionController::TestCase
   #logged in but insufficient permissions = ERROR
   test 'should get edit for learning_path owner' do
     sign_in @learning_path.user
+    get :edit, params: { id: @learning_path }
+    assert_response :success
+  end
+
+  test 'should get edit for learning path curator' do
+    sign_in users(:learning_path_curator)
     get :edit, params: { id: @learning_path }
     assert_response :success
   end
@@ -99,6 +109,14 @@ class LearningPathsControllerTest < ActionController::TestCase
   #CREATE TEST
   test 'should create learning_path for curator' do
     sign_in users(:curator)
+    assert_difference('LearningPath.count') do
+      post :create, params: { learning_path: { title: @learning_path.title, description: @learning_path.description } }
+    end
+    assert_redirected_to learning_path_path(assigns(:learning_path))
+  end
+
+  test 'should create learning_path for learning_path_curator' do
+    sign_in users(:learning_path_curator)
     assert_difference('LearningPath.count') do
       post :create, params: { learning_path: { title: @learning_path.title, description: @learning_path.description } }
     end
@@ -339,8 +357,8 @@ class LearningPathsControllerTest < ActionController::TestCase
     assert_select 'a.btn[href=?]', learning_path_path(@learning_path), count: 0 #No Edit
   end
 
-  test 'show action buttons when curator' do
-    sign_in users(:curator)
+  test 'show action buttons when learning_path_curator' do
+    sign_in users(:learning_path_curator)
 
     get :show, params: { id: @learning_path }
 
@@ -365,7 +383,7 @@ class LearningPathsControllerTest < ActionController::TestCase
   end
 
   test 'should allow access to private learning_paths if privileged' do
-    sign_in users(:curator)
+    sign_in users(:learning_path_curator)
     get :show, params: { id: learning_paths(:in_development_learning_path) }
     assert_response :success
   end

--- a/test/fixtures/roles.yml
+++ b/test/fixtures/roles.yml
@@ -23,3 +23,7 @@ basic_user:
 unverified_user: # Content requires approval before being visible
   name: unverified_user
   title: New user
+
+learning_path_curator:
+  name: learning_path_curator
+  title: Learning path curator

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -78,7 +78,6 @@ banned_user:
   role: user
   authentication_token: <%= Devise.friendly_token %>
 
-
 shadowbanned_user:
   username: Chad O'Band
   email: 'sbanned@notarealdomain.org'
@@ -151,3 +150,10 @@ upcase_username_and_email:
   email: 'MixedCaseEmail@example.com'
   encrypted_password: <%= Devise::Encryptor.digest(User, 'private') %>
   confirmed_at: <%= Time.zone.now %>
+
+learning_path_curator:
+  username: 'lp_cur8r'
+  email: 'lpc@example.com'
+  encrypted_password: 'learning_paths_curator_encrypted_password'
+  confirmed_at: <%= Time.zone.now %>
+  role: learning_path_curator


### PR DESCRIPTION
**Summary of changes**

- Adds an extra user role - "Learning path curator"

**Motivation and context**

Needed a role that allows modification of learning paths, but without the ability to edit all types resources (like the "curator" role provides).

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
