### PR TITLE
Hide learning paths help section if the feature is not enabled

### DIFF
--- a/app/views/about/_about_nav.html.erb
+++ b/app/views/about/_about_nav.html.erb
@@ -20,16 +20,18 @@
   </ul>
 
   <!-- REGISTERING YOUR LEARNING PATHS -->
-  <ul class="nav nav-stacked <%= show_active(show, 'learningpaths') %>">
-    <li class="about-page-category">
-      <%= link_to 'Learning Paths', registering_learning_paths_path %>
-    </li>
-    <li><%= about_nav_link('Editorial process', registering_learning_paths_path, 'editorial') %></li>
-    <li><%= about_nav_link('Overview of registering learning paths', registering_learning_paths_path, 'overview') %></li>
-    <li><%= about_nav_link('Learning path topics', registering_learning_paths_path, 'topics') %></li>
-    <li><%= about_nav_link('Registering learning paths', registering_learning_paths_path, 'register_paths') %></li>
-    <li><%= about_nav_link('Viewing learning paths', registering_learning_paths_path, 'viewing') %></li>
-  </ul>
+  <% if TeSS::Config.feature['learning_paths'] %>
+    <ul class="nav nav-stacked <%= show_active(show, 'learning_paths') %>">
+      <li class="about-page-category">
+        <%= link_to 'Learning Paths', registering_learning_paths_path %>
+      </li>
+      <li><%= about_nav_link('Editorial process', registering_learning_paths_path, 'editorial') %></li>
+      <li><%= about_nav_link('Overview of registering learning paths', registering_learning_paths_path, 'overview') %></li>
+      <li><%= about_nav_link('Learning path topics', registering_learning_paths_path, 'topics') %></li>
+      <li><%= about_nav_link('Registering learning paths', registering_learning_paths_path, 'register_paths') %></li>
+      <li><%= about_nav_link('Viewing learning paths', registering_learning_paths_path, 'viewing') %></li>
+    </ul>
+  <% end %>
 
   <!-- DEVELOPERS -->
   <ul class="nav nav-stacked <%= show_active(show, 'developers') %>">

--- a/app/views/about/_links.html.erb
+++ b/app/views/about/_links.html.erb
@@ -1,7 +1,9 @@
 <div class="quick-links">
   <%= link_to 'What is ' + TeSS::Config.site['title_short'] + '?', about_path, class: ('selected-tab' if show == 'tess') %>
   | <%= link_to 'How to Register', registering_resources_path, class: ('selected-tab' if show == 'registering') %>
-  | <%= link_to 'Learning Paths', registering_learning_paths_path, class: ('selected-tab' if show == 'learningpaths') %>
+  <% if TeSS::Config.feature['learning_paths'] %>
+    | <%= link_to 'Learning Paths', registering_learning_paths_path, class: ('selected-tab' if show == 'learning_paths') %>
+  <% end %>
   | <%= link_to 'Developers Guide', developers_path, class: ('selected-tab' if show == 'developer') %>
   | <%= link_to 'About us', us_path, class: ('selected-tab' if show == 'about') %>
 </div>

--- a/app/views/about/learning_paths.html.erb
+++ b/app/views/about/learning_paths.html.erb
@@ -1,6 +1,6 @@
 <div class="wrapper">
   <div id="sidebar" class="popout-sidebar">
-    <%= render partial: 'about_nav', locals: { show: 'learningpaths' } %>
+    <%= render partial: 'about_nav', locals: { show: 'learning_paths' } %>
   </div>
 
   <div id="content">

--- a/test/controllers/about_controller_test.rb
+++ b/test/controllers/about_controller_test.rb
@@ -6,6 +6,7 @@ class AboutControllerTest < ActionController::TestCase
   test 'should get first about page' do
     get :tess
     assert_response :success
+    assert_select 'li.about-page-category a[href=?]', registering_learning_paths_path, count: 1
   end
 
   test 'should get about us' do
@@ -13,16 +14,33 @@ class AboutControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-
   test 'should get about registering' do
     get :registering
     assert_response :success
   end
-
 
   test 'should get about developers' do
     get :developers
     assert_response :success
   end
 
+  test 'should get about learning paths' do
+    get :learning_paths
+    assert_response :success
+  end
+
+  test 'should not list learning path help if feature disabled' do
+    with_settings(feature: { learning_paths: false }) do
+      get :tess
+      assert_response :success
+      assert_select 'li.about-page-category a[href=?]', registering_learning_paths_path, count: 0
+    end
+  end
+
+  test 'should access learning paths help directly even if feature disabled' do
+    with_settings(feature: { learning_paths: false }) do
+      get :learning_paths
+      assert_response :success
+    end
+  end
 end


### PR DESCRIPTION
**Summary of changes**

- Hides the learning path block from the sidebar and footer of the "About" pages if the feature is switched off. Can still visit the page directly via URL though.

**Motivation and context**

User confusion

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
