### PR TITLE
Make the sort options go through i18n.

### DIFF
--- a/app/views/search/common/_facet_sidebar.html.erb
+++ b/app/views/search/common/_facet_sidebar.html.erb
@@ -13,11 +13,14 @@ Variable that should be available
 
 <%
   extras = if resource_type.name == 'Event'
-             [['Earliest', 'early'], ['Latest', 'late'], ['Most recent', 'new']]
+             [[t('sidebar.sort.values.earliest'), 'early'],
+              [t('sidebar.sort.values.latest'), 'late'],
+              [t('sidebar.sort.values.most_recent'), 'new']]
            elsif resource_type.name == 'Source'
-             [['Most recent', 'new'], ['Last finished', 'finished']]
+             [[t('sidebar.sort.values.most_recent'), 'new'],
+              [t('sidebar.sort.values.last_finished'), 'finished']]
            else
-             [['Most recent', 'new']]
+             [[t('sidebar.sort.values.most_recent'), 'new']]
            end %>
 
 <%= render partial: 'search/common/sort_by', locals: { resources: resource_type, extras: extras } %>

--- a/app/views/search/common/_sort_by.html.erb
+++ b/app/views/search/common/_sort_by.html.erb
@@ -2,17 +2,19 @@
 Parameters:
 Extras - Array of Arrays with options for select
 e.g.
- [['Earliest', 'early'], ['Latest', 'late']]
+ [[t('sidebar.sort.values.earliest'), 'early'],
+  [t('sidebar.sort.values.latest'), 'late']]
 %>
 <% if defined? extras %>
     <% extras = extras.reverse! || false %>
 <% end %>
 
+
 <% options = [
-    ['Title ascending', 'asc'],
-    ['Title descending', 'desc'],
-    ['Last modified', 'mod'],
-  # ['Relevance', 'rel']
+    [t('sidebar.sort.values.title_ascending'), 'asc'],
+    [t('sidebar.sort.values.title_descending'), 'desc'],
+    [t('sidebar.sort.values.last_modified'), 'mod'],
+  # [t('sidebar.sort.values.relevance'), 'rel']
 ] %>
 
 <% if extras %>
@@ -21,7 +23,7 @@ e.g.
 <% end %>
 
 <ul class="unstyled nav-simple facet-sort-wrap">
-  <li><h4 class="nav-heading">Sort</h4></li>
+  <li><h4 class="nav-heading"><%= t('sidebar.sort.heading') %></h4></li>
   <li class="sidebar-group">
     <ul>
       <li class="facet-sort-group">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -748,3 +748,15 @@ en:
   mailer:
     events_require_approval:
       subject: "Last week's events on %{site_name}"
+  sidebar:
+    sort:
+      heading: Sort
+      values:
+        title_ascending: Title ascending
+        title_descending: Title descending
+        last_modified: Last modified
+        relevance: Relevance
+        earliest: Earliest
+        latest: Latest
+        most_recent: Most recent
+        last_finished: Last finished


### PR DESCRIPTION
**Summary of changes**

The strings used in the sort options for search now go through i18n.

**Motivation and context**

As has come up elsewhere, a Canadian fork for TeSS is striving to make an English/French bilingual instance. There are many places in the TeSS code base where strings in the view don't go through i18n. This PR just handles just the sort options for searching. (Note: I think it might be better to send these improvements in smaller atomic PRs rather than in one mega-PR.)
 
**Screenshots**

Looks the same as before.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
