### PR TITLE
Only count upcoming events in tab title

### DIFF
--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -25,17 +25,22 @@
     <div class="my-3">
       <% materials = @collection.material_items %>
       <% materials_count = materials.count %>
-      <% events = @collection.event_items %>
-      <% events_count = events.count %>
+      <% event_items = @collection.event_items %>
+      <% e = @collection.events.from_verified_users.not_disabled %>
+      <% events_count = e.count %>
+      <% not_finished_events_count = e.not_finished.count %>
       <% activator = tab_activator %>
       <ul class="nav nav-tabs">
-        <%= tab('Materials', icon_class_for_model('materials'), 'materials', activator: activator,
-                disabled: { check: materials_count.zero?, message: 'No associated training materials' },
-                count: materials_count) %>
-
-        <%= tab('Events', icon_class_for_model('events'), 'events', activator: activator,
-                disabled: { check: events_count.zero?, message: 'No associated events' },
-                count: events_count) %>
+        <% if TeSS::Config.feature['materials'] %>
+          <%= tab('Materials', icon_class_for_model('materials'), 'materials', activator: activator,
+                  disabled: { check: materials_count.zero?, message: 'No registered training materials' },
+                  count: materials_count) %>
+        <% end %>
+        <% if TeSS::Config.feature['events'] %>
+          <%= tab('Events', icon_class_for_model('events'), 'events', activator: activator,
+                  disabled: { check: events_count.zero?, message: 'No associated events' },
+                  count: not_finished_events_count.zero? && events_count.positive? ? '0*' : not_finished_events_count) %>
+        <% end %>
       </ul>
     </div>
 
@@ -52,7 +57,7 @@
       <% if TeSS::Config.feature['events'] %>
         <%= render partial: 'common/associated_events',
                    locals: { total_count: events_count,
-                             resources: events,
+                             resources: event_items,
                              activator: activator,
                              view_all_link: events_path(collections: @collection.title, include_expired: true) } %>
       <% end %>

--- a/app/views/content_providers/show.html.erb
+++ b/app/views/content_providers/show.html.erb
@@ -26,17 +26,22 @@
       <% upcoming_events = @content_provider.events.from_verified_users.not_finished.not_disabled %>
       <% past_events = @content_provider.events.from_verified_users.finished.not_disabled %>
       <% events = upcoming_events.limit(resource_limit) %>
-      <% events_count =  @content_provider.events.from_verified_users.not_disabled.count %>
+      <% e = @content_provider.events.from_verified_users.not_disabled %>
+      <% events_count = e.count %>
+      <% not_finished_events_count = e.not_finished.count %>
       <% sources = @content_provider.sources.order(enabled: :desc, finished_at: :desc) %>
       <% activator = tab_activator %>
       <ul class="nav nav-tabs">
-        <%= tab('Materials', icon_class_for_model('materials'), 'materials', activator: activator,
-                disabled: { check: materials_count.zero?, message: 'No associated training materials' },
-                count: materials_count) %>
-
-        <%= tab('Events', icon_class_for_model('events'), 'events', activator: activator,
-                disabled: { check: events_count.zero?, message: 'No associated events' },
-                count: events_count) %>
+        <% if TeSS::Config.feature['materials'] %>
+          <%= tab('Materials', icon_class_for_model('materials'), 'materials', activator: activator,
+                  disabled: { check: materials_count.zero?, message: 'No registered training materials' },
+                  count: materials_count) %>
+        <% end %>
+        <% if TeSS::Config.feature['events'] %>
+          <%= tab('Events', icon_class_for_model('events'), 'events', activator: activator,
+                  disabled: { check: events_count.zero?, message: 'No associated events' },
+                  count: not_finished_events_count.zero? && events_count.positive? ? '0*' : not_finished_events_count) %>
+        <% end %>
 
         <% if TeSS::Config.feature['sources'] && policy(@content_provider).update? %>
           <%= tab('Sources', icon_class_for_model('sources'), 'sources', count: sources.count, activator: activator) %>

--- a/app/views/learning_path_topics/show.html.erb
+++ b/app/views/learning_path_topics/show.html.erb
@@ -47,17 +47,22 @@
     <div class="my-3">
       <% materials = @learning_path_topic.material_items %>
       <% materials_count = materials.count %>
-      <% events = @learning_path_topic.event_items %>
-      <% events_count = events.count %>
+      <% event_items = @learning_path_topic.event_items %>
+      <% e = @learning_path_topic.events.from_verified_users.not_disabled %>
+      <% events_count = e.count %>
+      <% not_finished_events_count = e.not_finished.count %>
       <% activator = tab_activator %>
       <ul class="nav nav-tabs">
-        <%= tab('Materials', icon_class_for_model('materials'), 'materials', activator: activator,
-                disabled: { check: materials_count.zero?, message: 'No associated training materials' },
-                count: materials_count) %>
-
-        <%# tab('Events', icon_class_for_model('events'), 'events', activator: activator,
-                disabled: { check: events_count.zero?, message: 'No associated events' },
-                count: events_count) %>
+        <% if TeSS::Config.feature['materials'] %>
+          <%= tab('Materials', icon_class_for_model('materials'), 'materials', activator: activator,
+                  disabled: { check: materials_count.zero?, message: 'No registered training materials' },
+                  count: materials_count) %>
+        <% end %>
+        <% if TeSS::Config.feature['events'] %>
+          <%# tab('Events', icon_class_for_model('events'), 'events', activator: activator,
+                  disabled: { check: events_count.zero?, message: 'No associated events' },
+                  count: not_finished_events_count.zero? && events_count.positive? ? '0*' : not_finished_events_count) %>
+        <% end %>
       </ul>
     </div>
 
@@ -74,7 +79,7 @@
       <% if TeSS::Config.feature['events'] %>
         <%= render partial: 'common/associated_events',
                    locals: { total_count: events_count,
-                             resources: events,
+                             resources: event_items,
                              activator: activator,
                              view_all_link: events_path(collections: @learning_path_topic.title, include_expired: true) } %>
       <% end %>

--- a/app/views/nodes/show.html.erb
+++ b/app/views/nodes/show.html.erb
@@ -23,7 +23,9 @@
       <% upcoming_events = @node.related_events.from_verified_users.not_finished %>
       <% past_events = @node.related_events.from_verified_users.finished %>
       <% events = upcoming_events.limit(resource_limit) %>
-      <% events_count =  @node.related_events.from_verified_users.count %>
+      <% e = @node.events.from_verified_users.not_disabled %>
+      <% events_count = e.count %>
+      <% not_finished_events_count = e.not_finished.count %>
       <% activator = tab_activator %>
       <ul class="nav nav-tabs">
         <% if TeSS::Config.feature['materials'] %>
@@ -33,8 +35,8 @@
         <% end %>
         <% if TeSS::Config.feature['events'] %>
           <%= tab('Events', icon_class_for_model('events'), 'events', activator: activator,
-                  disabled: { check: events_count.zero?, message: 'No registered events' },
-                  count: events_count) %>
+                  disabled: { check: events_count.zero?, message: 'No associated events' },
+                  count: not_finished_events_count.zero? && events_count.positive? ? '0*' : not_finished_events_count) %>
         <% end %>
         <% if TeSS::Config.feature['content_providers'] %>
           <%= tab('Providers', icon_class_for_model('content_providers'), 'content_providers', activator: activator,

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -131,7 +131,9 @@
       <% upcoming_events = @user.events.not_finished %>
       <% past_events = @user.events.finished %>
       <% events = upcoming_events.limit(resource_limit) %>
-      <% events_count =  @user.events.count %>
+      <% e = @user.events.from_verified_users.not_disabled %>
+      <% events_count = e.count %>
+      <% not_finished_events_count = e.not_finished.count %>
       <% workflows = @user.workflows.visible_by(current_user).limit(resource_limit) %>
       <% workflows_count =  @user.workflows.visible_by(current_user).count %>
       <% collections = @user.collections.visible_by(current_user).limit(resource_limit) %>
@@ -142,8 +144,8 @@
         <!-- Tab: Events -->
         <% if TeSS::Config.feature['events'] %>
           <%= tab('Events', icon_class_for_model('events'), 'events', activator: activator,
-                  disabled: { check: events_count.zero?, message: 'No registered events' },
-                  count: events_count) %>
+                  disabled: { check: events_count.zero?, message: 'No associated events' },
+                  count: not_finished_events_count.zero? && events_count.positive? ? '0*' : not_finished_events_count) %>
         <% end %>
 
         <!-- Tab: Materials -->

--- a/test/controllers/content_providers_controller_test.rb
+++ b/test/controllers/content_providers_controller_test.rb
@@ -478,7 +478,7 @@ class ContentProvidersControllerTest < ActionController::TestCase
     dateless_event.save!
 
     get :show, params: { id: @content_provider }
-    assert_select 'a[href=?]', '#events', text: 'Events (3)'
+    assert_select 'a[href=?]', '#events', text: 'Events (2)' # 2 Upcoming events
     # this is a bit fragile. may be nicer to use a regex if it breaks
     assert_select 'div#events div.search-results-count', text: /Showing 2 events/ do
       assert_select 'span', text: '(also found 1 past event)'

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -404,17 +404,18 @@ class UsersControllerTest < ActionController::TestCase
   test 'should show tabs for resource types and link to view all' do
     sign_in(@user)
 
-    assert @user.events.not_finished.count > 0
-    assert @user.materials.count > 1
-    assert @user.collections.count > 1
-    assert @user.workflows.count > 1
+    travel_to(Date.new(2024, 10, 21)) do
+      assert @user.events.not_finished.count > 0
+      assert @user.materials.count > 1
+      assert @user.collections.count > 1
+      assert @user.workflows.count > 1
 
-    UsersHelper.stub(:user_profile_resource_limit, 1) do
-      get :show, params: { id: @user }
+      UsersHelper.stub(:user_profile_resource_limit, 1) do
+        get :show, params: { id: @user }
+      end
     end
-
     # Tabs
-    assert_select 'a[data-toggle="tab"]', text: "Events (#{@user.events.count})"
+    assert_select 'a[data-toggle="tab"]', text: "Events (#{@user.events.not_finished.count})"
     assert_select 'a[data-toggle="tab"]', text: "Materials (#{@user.materials.count})"
     assert_select 'a[data-toggle="tab"]', text: "Collections (#{@user.collections.count})"
     assert_select 'a[data-toggle="tab"]', text: "Workflows (#{@user.workflows.count})"
@@ -437,7 +438,7 @@ class UsersControllerTest < ActionController::TestCase
       get :show, params: { id: user }
     end
 
-    assert_select 'a[data-toggle="tab"]', text: "Events (#{user.events.count})"
+    assert_select 'a[data-toggle="tab"]', text: "Events (0*)"
     assert_select '#events a[href=?]', events_path(user: user.username, include_expired: true)
   end
 


### PR DESCRIPTION
**Summary of changes**

- Show upcoming count instead of all event count (with asterisk if no upcoming but some past events).

**Motivation and context**

Past events are not as relevant to users.
 
**Screenshots**

![image](https://github.com/user-attachments/assets/2a01e7f4-4032-4ec9-9e94-7e2f35878a66)

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
