### PR TITLE
Making entire about page content go through i18n.

### DIFF
--- a/app/views/about/_about_nav.html.erb
+++ b/app/views/about/_about_nav.html.erb
@@ -3,50 +3,54 @@
   <!-- WHAT IS TESS -->
   <ul class="nav nav-stacked <%= show_active(show, 'home') %>">
     <li class="about-page-category">
-      <%= link_to 'What is ' + TeSS::Config.site['title_short'] + '?', about_path %>
+      <%= link_to t('about.sidebar.what_is', title: TeSS::Config.site['title_short']), about_path %>
     </li>
-    <li><%= about_nav_link('What we catalogue', about_path, 'events') %></li>
-    <li><%= about_nav_link('Subscribing to notifications', about_path, 'subscribe') %></li>
-    <li><%= about_nav_link('Widgets & API', about_path, 'widget') %></li>
+    <li><%= about_nav_link(t('about.sidebar.what_we_catalogue'), about_path, 'events') %></li>
+    <li><%= about_nav_link(t('about.sidebar.subscribing_to_notifications'),
+            about_path, 'subscribe') %></li>
+    <li><%= about_nav_link(t('about.sidebar.widgets_and_api'),
+            about_path, 'widget') %></li>
   </ul>
 
   <!-- REGISTERING YOUR RESOURCES -->
   <ul class="nav nav-stacked <%= show_active(show, 'registering') %>">
     <li class="about-page-category">
-      <%= link_to 'Registering Content', registering_resources_path %>
+      <%= link_to t('about.sidebar.registering_content'), registering_resources_path %>
     </li>
-    <li><%= about_nav_link('Automatic Registration', registering_resources_path, 'automatic') %></li>
-    <li><%= about_nav_link('Manual Registration', registering_resources_path, 'manual') %></li>
+    <li><%= about_nav_link(t('about.sidebar.automatic_registration'),
+            registering_resources_path, 'automatic') %></li>
+    <li><%= about_nav_link(t('about.sidebar.manual_registration'),
+            registering_resources_path, 'manual') %></li>
   </ul>
 
   <!-- REGISTERING YOUR LEARNING PATHS -->
   <% if TeSS::Config.feature['learning_paths'] %>
     <ul class="nav nav-stacked <%= show_active(show, 'learning_paths') %>">
       <li class="about-page-category">
-        <%= link_to 'Learning Paths', registering_learning_paths_path %>
+        <%= link_to t('about.sidebar.learning_paths'), registering_learning_paths_path %>
       </li>
-      <li><%= about_nav_link('Editorial process', registering_learning_paths_path, 'editorial') %></li>
-      <li><%= about_nav_link('Overview of registering learning paths', registering_learning_paths_path, 'overview') %></li>
-      <li><%= about_nav_link('Learning path topics', registering_learning_paths_path, 'topics') %></li>
-      <li><%= about_nav_link('Registering learning paths', registering_learning_paths_path, 'register_paths') %></li>
-      <li><%= about_nav_link('Viewing learning paths', registering_learning_paths_path, 'viewing') %></li>
+      <li><%= about_nav_link(t('about.sidebar.editorial_process'), registering_learning_paths_path, 'editorial') %></li>
+      <li><%= about_nav_link(t('about.sidebar.overview_of_registering_learning_paths'), registering_learning_paths_path, 'overview') %></li>
+      <li><%= about_nav_link(t('about.sidebar.learning_path_topics'), registering_learning_paths_path, 'topics') %></li>
+      <li><%= about_nav_link(t('about.sidebar.registering_learning_paths'), registering_learning_paths_path, 'register_paths') %></li>
+      <li><%= about_nav_link(t('about.sidebar.viewing_learning_paths'), registering_learning_paths_path, 'viewing') %></li>
     </ul>
   <% end %>
 
   <!-- DEVELOPERS -->
   <ul class="nav nav-stacked <%= show_active(show, 'developers') %>">
     <li class="about-page-category">
-      <%= link_to 'Developers', developers_path %>
+      <%= link_to t('about.sidebar.developers'), developers_path %>
     </li>
-    <li><%= about_nav_link('Code and Data', developers_path, 'code_and_data') %></li>
-    <li><%= about_nav_link('Widgets', developers_path, 'widgets') %></li>
-    <li><%= about_nav_link('API', developers_path, 'api') %></li>
+    <li><%= about_nav_link(t('about.sidebar.code_and_data'), developers_path, 'code_and_data') %></li>
+    <li><%= about_nav_link(t('about.sidebar.widgets'), developers_path, 'widgets') %></li>
+    <li><%= about_nav_link(t('about.sidebar.api'), developers_path, 'api') %></li>
   </ul>
 
   <!-- ABOUT US -->
   <ul class="nav nav-stacked <%= show_active(show, 'us') %>">
     <li class="about-page-category">
-      <%= link_to 'About Us', us_path %>
+      <%= link_to t('about.sidebar.about_us'), us_path %>
     </li>
     <% 
       about_us_tabs = [

--- a/app/views/about/tess.html.erb
+++ b/app/views/about/tess.html.erb
@@ -15,7 +15,7 @@
       <!-- EVENTS-->
       <% if TeSS::Config.feature['events'] == true %>
         <div id="events" class="row <%= next_about_block(@feature_count += 1) %>">
-          <h3 class="col-lg-12">Events</h3>
+          <h3 class="col-lg-12"><%= t('about.headings.events') %></h3>
           <div class="col-lg-2 col-lg-push-10 about-resource-icon">
             <%= image_tag('modern/icons/events-icon.svg', height: '65px', alt: 'Events') %>
           </div>
@@ -36,7 +36,7 @@
       <!-- MATERIALS-->
       <% if TeSS::Config.feature['materials'] == true %>
         <div id="materials" class="row <%= next_about_block(@feature_count += 1) %>">
-          <h3 class="col-lg-12">Materials</h3>
+          <h3 class="col-lg-12"><%= t('about.headings.materials') %></h3>
 
           <div class="col-lg-2 col-lg-push-10 about-resource-icon">
             <%= image_tag('modern/icons/materials-icon.svg', height: '65px', alt: 'Materials') %>
@@ -60,7 +60,7 @@
       <!-- WORKFLOWS -->
       <% if TeSS::Config.feature['workflows'] == true %>
         <div id="workflows" class="row <%= next_about_block(@feature_count += 1) %>">
-          <h3 class="col-lg-12">Training Workflows</h3>
+          <h3 class="col-lg-12"><%= t('about.headings.workflows') %></h3>
           <div class="col-lg-2 col-lg-push-10 about-resource-icon">
             <%= link_to workflows_path do %>
               <%= image_tag('modern/icons/workflows-icon.svg', height: "65px", alt: "Workflows") %>
@@ -75,23 +75,23 @@
           <div class="col-lg-12">
             <!-- INDIVIDUAL WORKFLOW TYPES-->
             <div class="sub-about-block">
-              <h4>Learning Paths</h4>
+              <h4><%= t('about.headings.learning_paths') %></h4>
               <p><%== t 'about.learning_paths' %></p>
 
               <%= link_to registering_learning_paths_path do %>
-                Discover Learning Paths <i class="icon icon-sm arrow-right-icon"></i>
+                <%= t('about.discover_learning_paths') %><i class="icon icon-sm arrow-right-icon"></i>
               <% end %>
             </div>
 
             <div class="sub-about-block">
-              <h4>Educational Resource</h4>
+              <h4><%= t('about.headings.educational_resource') %></h4>
               <p><%== t 'about.resources' %></p>
             </div>
 
             <br/>
 
             <%= link_to workflows_path do %>
-              Discover Workflows <i class="icon icon-sm arrow-right-icon"></i>
+              <%= t('about.discover_workflows') %> <i class="icon icon-sm arrow-right-icon"></i>
             <% end %>
           </div>
         </div>
@@ -100,7 +100,7 @@
       <!-- SUBSCRIBE-->
       <% if TeSS::Config.feature['subscription'] %>
         <div id="subscribe" class="<%= next_about_block(@feature_count += 1) %>">
-          <h3>Subscribe</h3>
+          <h3><%= t('about.headings.subscribe') %></h3>
           <p><%== t 'about.subscribe' %></p>
           <p><%== t('about.subscription_manager', subscriptions_path: subscriptions_path) %></p>
           <%= image_tag 'about/subscription.png', style: 'width: 80%' %>
@@ -109,10 +109,12 @@
 
       <!-- WIDGET & API -->
       <div id="widget" class="<%= next_about_block(@feature_count += 1) %>">
-        <h3>Widgets & API</h3>
+        <h3><%= t('about.headings.widgets_and_api') %></h3>
         <p><%== t 'about.widgets_and_api' %></p>
-        <%= link_to 'Learn more about Widgets', developers_path(anchor: 'widgets'), class: 'btn btn-default' %>
-        <%= link_to 'Learn more about our API', developers_path(anchor: 'api'), class: 'btn btn-default' %>
+        <%= link_to t('about.links.learn_more_widgets'),
+            developers_path(anchor: 'widgets'), class: 'btn btn-default' %>
+        <%= link_to t('about.links.learn_more_api'),
+            developers_path(anchor: 'api'), class: 'btn btn-default' %>
       </div>
     </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,6 +65,36 @@ en:
           hybrid: Hybrid
         language: 'Language of instruction'
   about:
+    headings:
+      events: Events
+      materials: Materials
+      workflows: Training Workflows
+      learning_paths: Learning Paths
+      educational_resource: Educational Resource
+      subscribe: Subscribe
+      widgets_and_api: Widgets & API
+    sidebar:
+      what_is: 'What is %{title}?'
+      what_we_catalogue: 'What we catalogue'
+      subscribing_to_notifications: 'Subscribing to notifications'
+      widgets_and_api: Widgets & API
+      registering_content: 'Registering Content'
+      automatic_registration: 'Automatic Registration'
+      manual_registration: 'Manual Registration'
+      learning_paths: 'Learning Paths'
+      editorial_process: 'Editorial process'
+      overview_of_registering_learning_paths: 'Overview of registering learning paths'
+      learning_path_topics: 'Learning path topics'
+      registering_learning_paths: 'Registering learning paths'
+      viewing_learning_paths: 'Viewing learning paths'
+      developers: 'Developers'
+      code_and_data: 'Code and Data'
+      widgets: 'Widgets'
+      api: 'API'
+      about_us: 'About Us'
+    links:
+      learn_more_widgets: Learn more about Widgets
+      learn_more_api: Learn more about our API
     registry: >
       TeSS is a platform that was developed to provide a one-stop shop for trainers and trainees to discover
       online information and content, including training materials, events and interactive tutorials.
@@ -121,6 +151,8 @@ en:
     discover_events: Discover Events
     collect_materials: "%{site_name} collects materials from %{count} content providers."
     discover_materials: Discover Materials
+    discover_learning_paths: Discover Learning Paths
+    discover_workflows: Discover Workflows
   developer:
     license: >
       TeSS is committed to the FAIR principles: making data findable, accessible, interoperable and re-usable.


### PR DESCRIPTION
**Summary of changes**

Making sure the entire view for the about page goes through i18n.

**Motivation and context**

There are a lot of strings on the about page that don't go through i18n. This fixes that.
 
**Screenshots**

Looks the same as before.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
