### PR TITLE
Show learning path navigation box when looking at an item from a learning path

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -260,6 +260,8 @@ document.addEventListener("turbolinks:load", function(e) {
 
     Collections.init();
 
+    LearningPaths.init();
+
     $('.tess-expandable').each(function () {
         var limit = this.dataset.heightLimit || 300;
 
@@ -326,12 +328,6 @@ document.addEventListener("turbolinks:load", function(e) {
         }, 1);
     });
 
-    $('.learning-path-topic-title').click(function () {
-        const container = $(this).closest('.learning-path-topic');
-        const contents = container.find('.learning-path-topic-contents');
-        $(this).find('.expand-icon, .collapse-icon').toggleClass('collapse-icon').toggleClass('expand-icon');
-        contents.slideToggle();
-    });
 });
 
 function truncateWithEllipses(text, max)

--- a/app/assets/javascripts/learning_paths.js
+++ b/app/assets/javascripts/learning_paths.js
@@ -1,0 +1,17 @@
+var LearningPaths = {
+    init: function () {
+        $('.learning-path-topic-title').click(function () {
+            const container = $(this).closest('.learning-path-topic');
+            const contents = container.find('.learning-path-topic-contents');
+            $(this).find('.expand-icon, .collapse-icon').toggleClass('collapse-icon').toggleClass('expand-icon');
+            contents.slideToggle();
+        });
+
+        if (window.location.hash) {
+            var topic = $('.learning-path-topic' + window.location.hash);
+            if (topic.length) {
+                $('.learning-path-topic-title', topic).click();
+            }
+        }
+    }
+}

--- a/app/controllers/materials_controller.rb
+++ b/app/controllers/materials_controller.rb
@@ -4,6 +4,7 @@ class MaterialsController < ApplicationController
   before_action :set_material, only: [:show, :edit, :update, :destroy, :update_collections, :clone,
                                       :add_term, :reject_term, :add_data, :reject_data]
   before_action :set_breadcrumbs
+  before_action :set_learning_path_navigation, only: :show
 
   include SearchableIndex
   include ActionView::Helpers::TextHelper
@@ -178,4 +179,10 @@ class MaterialsController < ApplicationController
                                      event_ids: [], locked_fields: [])
   end
 
+  def set_learning_path_navigation
+    return unless params[:lp]
+    topic_link_id, topic_item_id = params[:lp].split(':')
+    @learning_path_topic_link = LearningPathTopicLink.find_by_id(topic_link_id)
+    @learning_path_topic_item = LearningPathTopicItem.find_by_id(topic_item_id)
+  end
 end

--- a/app/helpers/learning_paths_helper.rb
+++ b/app/helpers/learning_paths_helper.rb
@@ -1,0 +1,7 @@
+module LearningPathsHelper
+
+  def learning_path_breadcrumb_param(topic_link, topic_item)
+    { lp: [topic_link, topic_item].map(&:id).join(':') }
+  end
+
+end

--- a/app/models/learning_path_topic_item.rb
+++ b/app/models/learning_path_topic_item.rb
@@ -19,6 +19,14 @@ class LearningPathTopicItem < ApplicationRecord
                                                 topic_title: self.topic.title })
   end
 
+  def previous_item
+    topic.items.where(order: order - 1).first
+  end
+
+  def next_item
+    topic.items.where(order: order + 1).first
+  end
+
   private
 
   def set_order

--- a/app/models/learning_path_topic_link.rb
+++ b/app/models/learning_path_topic_link.rb
@@ -7,6 +7,14 @@ class LearningPathTopicLink < ApplicationRecord
 
   validates :topic_id, uniqueness: { scope: %i[learning_path_id], message: 'already included in learning path' }
 
+  def previous_topic
+    learning_path.topic_links.where(order: order - 1).first
+  end
+
+  def next_topic
+    learning_path.topic_links.where(order: order + 1).first
+  end
+
   private
 
   def set_order

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -1,6 +1,8 @@
+<% learning_path_topic_item ||= nil %>
+<% collection_item ||= learning_path_topic_item %>
 <li class="masonry-brick media-item long">
   <%= link_to event, class: 'link-overlay with-left-icon' do %>
-    <%= item_order_badge(collection_item) if defined? collection_item %>
+    <%= item_order_badge(collection_item) if collection_item %>
     <div class="with-left-icon">
       <div class="icon-container hidden-xs">
         <i class="icon icon-h2 <%= event.presence %>-event-icon"></i><br/>
@@ -52,6 +54,6 @@
       <% end %>
     </div>
 
-    <%= item_comment(collection_item) if defined? collection_item %>
+    <%= item_comment(collection_item) if collection_item %>
   <% end %>
 </li>

--- a/app/views/learning_path_topic_items/_learning_path_topic_item.html.erb
+++ b/app/views/learning_path_topic_items/_learning_path_topic_item.html.erb
@@ -1,3 +1,2 @@
 <% resource = learning_path_topic_item.resource %>
-<% locals = local_assigns.merge(collection_item: local_assigns.delete(:learning_path_topic_item)) %>
-<%= render partial: resource, locals: locals %>
+<%= render partial: resource, locals: local_assigns %>

--- a/app/views/learning_path_topic_items/_learning_path_topic_item.html.erb
+++ b/app/views/learning_path_topic_items/_learning_path_topic_item.html.erb
@@ -1,2 +1,3 @@
 <% resource = learning_path_topic_item.resource %>
-<%= render partial: resource, locals: { collection_item: learning_path_topic_item } %>
+<% locals = local_assigns.merge(collection_item: local_assigns.delete(:learning_path_topic_item)) %>
+<%= render partial: resource, locals: locals %>

--- a/app/views/learning_paths/partials/_navigation.html.erb
+++ b/app/views/learning_paths/partials/_navigation.html.erb
@@ -1,0 +1,23 @@
+<h4 class="nav-heading"><%= LearningPath.model_name.human %></h4>
+<div class="nav-block learning-path-navigation">
+  <%= link_to(topic_link.learning_path.title, topic_link.learning_path) %><br/>
+  <%= topic_link.topic.title %>
+
+  <%= item_comment(topic_item) %>
+
+  <div>
+    <% next_item = topic_item.next_item %>
+    <% if next_item %>
+      <strong><%= t('learning_paths.next_item') %>:</strong><br/>
+      <%= link_to(next_item.resource.title, polymorphic_path(next_item.resource, **learning_path_breadcrumb_param(topic_link, next_item))) %>
+    <% else %>
+      <% next_topic = topic_link.next_topic %>
+      <% if next_topic %>
+        <strong><%= t('learning_paths.next_topic') %>:</strong><br/>
+        <%= link_to(next_topic.topic.title, learning_path_path(next_topic.learning_path, anchor: "topic-#{next_topic.id}")) %>
+      <% else %>
+        <span class="empty"><%= t('learning_paths.end_of') %></span>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/learning_paths/show.html.erb
+++ b/app/views/learning_paths/show.html.erb
@@ -60,7 +60,7 @@
 
       <div class="learning-path-topics">
         <% @learning_path.topic_links.joins(:topic).each do |lpt| %>
-          <div class="learning-path-topic">
+          <div class="learning-path-topic" id="topic-<%= lpt.id -%>">
             <div class="learning-path-topic-order"><%= lpt.order %></div>
             <div class="learning-path-topic-title">
               <h4><%= lpt.topic.title %> <i class="icon icon-md expand-icon"></i></h4>
@@ -79,8 +79,9 @@
               <% end %>
 
               <ul style="padding-left: 0; overflow: auto;">
-                <% lpt.topic.materials.each do |object| %>
-                  <%= render object %>
+                <% lpt.topic.material_items.each do |object| %>
+                  <%= render partial: object.to_partial_path, locals: { learning_path_topic_item: object,
+                                                                        topic_link: lpt } %>
                 <% end %>
               </ul>
             </div>

--- a/app/views/learning_paths/show.html.erb
+++ b/app/views/learning_paths/show.html.erb
@@ -80,7 +80,8 @@
 
               <ul style="padding-left: 0; overflow: auto;">
                 <% lpt.topic.material_items.each do |object| %>
-                  <%= render partial: object.to_partial_path, locals: { learning_path_topic_item: object,
+                  <%= render partial: object.to_partial_path, locals: { show_order: false,
+                                                                        learning_path_topic_item: object,
                                                                         topic_link: lpt } %>
                 <% end %>
               </ul>

--- a/app/views/materials/_material.html.erb
+++ b/app/views/materials/_material.html.erb
@@ -1,6 +1,10 @@
+<% learning_path_topic_item ||= nil %>
+<% collection_item ||= learning_path_topic_item %>
+<% link_params = (defined? topic_link) ? learning_path_breadcrumb_param(topic_link, collection_item) : {} %>
+<% show_order = false unless defined? show_order %>
 <li class="masonry-brick media-item long">
-  <%= link_to material, class: 'link-overlay' do %>
-    <%= item_order_badge(collection_item) if defined? collection_item %>
+  <%= link_to material_path(material, **link_params), class: 'link-overlay' do %>
+    <%= item_order_badge(collection_item) if show_order && collection_item %>
 
     <div class="masonry-brick-heading">
       <div class="masonry-icons">
@@ -31,6 +35,6 @@
       <%= keywords_and_topics(material) %>
     </div>
 
-    <%= item_comment(collection_item) if defined? collection_item %>
+    <%= item_comment(collection_item) if collection_item %>
   <% end %>
 </li>

--- a/app/views/materials/_material.html.erb
+++ b/app/views/materials/_material.html.erb
@@ -1,7 +1,11 @@
 <% learning_path_topic_item ||= nil %>
 <% collection_item ||= learning_path_topic_item %>
 <% link_params = (defined? topic_link) ? learning_path_breadcrumb_param(topic_link, collection_item) : {} %>
-<% show_order = false unless defined? show_order %>
+<%
+  unless defined? show_order
+    show_order = true
+  end
+%>
 <li class="masonry-brick media-item long">
   <%= link_to material_path(material, **link_params), class: 'link-overlay' do %>
     <%= item_order_badge(collection_item) if show_order && collection_item %>

--- a/app/views/materials/show.html.erb
+++ b/app/views/materials/show.html.erb
@@ -1,5 +1,8 @@
 <div class="wrapper collapsing-wrapper">
   <div class="collapsing-sidebar" id="sidebar">
+    <%= render partial: 'learning_paths/partials/navigation',
+               locals: { topic_link: @learning_path_topic_link,
+                         topic_item: @learning_path_topic_item } if @learning_path_topic_link && @learning_path_topic_item %>
     <%= render partial: 'content_providers/partials/content_provider_info', locals: { content_provider: @material.content_provider } %>
     <%= render partial: 'nodes/partials/associated_node_info', locals: { associated_nodes: @material.associated_nodes } %>
     <%= render(partial: 'users/partials/user_info', locals: { user: @material.user }) if current_user.try(:is_admin?) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -670,6 +670,9 @@ en:
       resource_type: 'Select the type of resource that best matches the learning path. '
       url: 'Preferred URL to direct people to your learning path landing page.'
       version: 'Indicate the current version of the learning path.'
+    next_topic: Next topic
+    next_item: Next
+    end_of: End of learning path
   profile:
     user:
       disclaimer: >

--- a/test/controllers/learning_paths_controller_test.rb
+++ b/test/controllers/learning_paths_controller_test.rb
@@ -507,4 +507,15 @@ class LearningPathsControllerTest < ActionController::TestCase
     response_events = body.dig('data', 'relationships', 'events', 'data')
     assert_equal [events[1].id, events[0].id], response_events.map { |e| e['id'].to_i }
   end
+
+  test 'should include back-reference to learning path in item links' do
+    get :show, params: { id: @learning_path }
+
+    assert_response :success
+    topic_link = @learning_path.topic_links.first
+    topic_item = topic_link.topic.items.first
+
+    assert_select '.link-overlay[href=?]',
+                  material_path(topic_item.resource, lp: [topic_link, topic_item].map(&:id).join(':'))
+  end
 end

--- a/test/controllers/materials_controller_test.rb
+++ b/test/controllers/materials_controller_test.rb
@@ -364,6 +364,7 @@ class MaterialsControllerTest < ActionController::TestCase
       assert_select 'fa-commenting-o', count: 0
       assert_select '.broken-link-notice', count: 0
       assert_select '.archived-notice', count: 0
+      assert_select '.learning-path-navigation', count: 0
     end
   end
 
@@ -1474,5 +1475,70 @@ class MaterialsControllerTest < ActionController::TestCase
 
     get :show, params: { id: material }
     assert_response :forbidden
+  end
+
+  test 'should show learning path nav and link to next item' do
+    learning_path = learning_paths(:one)
+    topic_link = learning_path.topic_links.first
+    topic_item = topic_link.topic.material_items.first
+    material = topic_item.resource
+
+    get :show, params: { id: material, lp: [topic_link, topic_item].map(&:id).join(':') }
+
+    assert_response :success
+    assert assigns(:learning_path_topic_link)
+    assert assigns(:learning_path_topic_item)
+
+    next_item = assigns(:learning_path_topic_item).next_item
+    assert next_item
+
+    assert_select '.learning-path-navigation'
+    assert_select 'strong', text: 'Next:'
+    assert_select 'strong', text: 'Next topic:', count: 0
+    assert_select '.learning-path-navigation a[href=?]',
+                  material_path(next_item.resource, lp: [topic_link, next_item].map(&:id).join(':'))
+  end
+
+  test 'learning path nav should link to next topic' do
+    learning_path = learning_paths(:one)
+    topic_link = learning_path.topic_links.first
+    topic_item = topic_link.topic.material_items.last
+    material = topic_item.resource
+
+    get :show, params: { id: material, lp: [topic_link, topic_item].map(&:id).join(':') }
+
+    assert_response :success
+    assert assigns(:learning_path_topic_link)
+    assert assigns(:learning_path_topic_item)
+
+    next_topic = assigns(:learning_path_topic_link).next_topic
+    assert next_topic
+    refute assigns(:learning_path_topic_item).next_item
+
+    assert_select '.learning-path-navigation'
+    assert_select 'strong', text: 'Next:', count: 0
+    assert_select 'strong', text: 'Next topic:'
+    assert_select '.learning-path-navigation a[href=?]',
+                  learning_path_path(learning_path, anchor: "topic-#{next_topic.id}")
+  end
+
+  test 'learning path nav should indicate if final item in learning path' do
+    learning_path = learning_paths(:one)
+    topic_link = learning_path.topic_links.last
+    topic_item = topic_link.topic.material_items.last
+    material = topic_item.resource
+
+    get :show, params: { id: material, lp: [topic_link, topic_item].map(&:id).join(':') }
+
+    assert_response :success
+    assert assigns(:learning_path_topic_link)
+    assert assigns(:learning_path_topic_item)
+    refute assigns(:learning_path_topic_link).next_topic
+    refute assigns(:learning_path_topic_item).next_item
+
+    assert_select '.learning-path-navigation'
+    assert_select 'strong', text: 'Next:', count: 0
+    assert_select 'strong', text: 'Next topic:', count: 0
+    assert_select 'span.empty', text: 'End of learning path'
   end
 end

--- a/test/models/learning_path_test.rb
+++ b/test/models/learning_path_test.rb
@@ -89,4 +89,19 @@ class LearningPathTest < ActiveSupport::TestCase
     assert_equal [1, 2], learning_path.topic_links.pluck(:order)
     assert_equal [learning_path_topics(:goblet_things), learning_path_topics(:good_and_bad)], learning_path.topic_links.map(&:topic)
   end
+
+  test 'next_topic, previous_topic' do
+    learning_path = learning_paths(:in_development_learning_path)
+    topic_link1 = learning_path.topic_links.create!(topic: learning_path_topics(:good_and_bad), order: 1)
+    topic_link2 = learning_path.topic_links.create!(topic: learning_path_topics(:goblet_things), order: 2)
+    topic_link3 = learning_path.topic_links.create!(topic: learning_path_topics(:empty_topic), order: 3)
+
+    assert_equal topic_link2, topic_link1.next_topic
+    assert_equal topic_link3, topic_link2.next_topic
+    assert_nil topic_link3.next_topic
+
+    assert_equal topic_link2, topic_link3.previous_topic
+    assert_equal topic_link1, topic_link2.previous_topic
+    assert_nil topic_link1.previous_topic
+  end
 end

--- a/test/models/learning_path_topic_test.rb
+++ b/test/models/learning_path_topic_test.rb
@@ -70,4 +70,19 @@ class LearningPathTopicTest < ActiveSupport::TestCase
     assert_equal [1, 2], learning_path_topic.event_items.pluck(:order)
     assert_equal [events(:two), events(:one)], learning_path_topic.event_items.map(&:resource)
   end
+
+  test 'next_item, previous_item' do
+    learning_path_topic = learning_path_topics(:empty_topic)
+    item1 = learning_path_topic.items.create!(resource: materials(:biojs), order: 1)
+    item2 = learning_path_topic.items.create!(resource: materials(:interpro), order: 2)
+    item3 = learning_path_topic.items.create!(resource: materials(:good_material), order: 3)
+
+    assert_equal item2, item1.next_item
+    assert_equal item3, item2.next_item
+    assert_nil item3.next_item
+
+    assert_equal item2, item3.previous_item
+    assert_equal item1, item2.previous_item
+    assert_nil item1.previous_item
+  end
 end


### PR DESCRIPTION
**Summary of changes**

- When clicking through to a material from a learning path, adds a parameter to the URL with a reference back to the learning path/topic.
- If this parameter is present, displays a box in the left sidebar showing: the current learning path and topic, the comment on this item (if present), and a link to either the next item in the topic, or the next topic in the learning path (if there is one).

**Motivation and context**

#997
 
**Screenshots**
![image](https://github.com/user-attachments/assets/19307d23-bd99-4461-b499-d6e4ef08403c)

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
