### PR TITLE
Fix upcoming event listing on community page

### DIFF
--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -46,17 +46,18 @@ class CommunitiesController < ApplicationController
   def set_upcoming_events
     n_events = 5
 
-    Event.search_and_filter(
+    events = Event.search_and_filter(
       nil,
       '',
       {
-        'include_expired' => 'true',
         'start' => "#{10.years.ago.beginning_of_day}/",
         **@community.filters
       },
       sort_by: 'early',
       per_page: 5 * n_events
-    ).results.group_by(&:content_provider_id).map { |_p_id, p_events| p_events.first }.first(n_events)
+    ).results
+
+    @events = Event.from_varied_providers(events, n_events).sort_by(&:created_at).reverse
   end
 
   def set_community

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -464,6 +464,27 @@ class Event < ApplicationRecord
     self.presence = value
   end
 
+  # Method to ensure a good spread of events by picking one from each content provider until the limit hit,
+  # or no more events in set.
+  def self.from_varied_providers(events, count)
+    provider_events = events.group_by(&:content_provider_id)
+
+    events = []
+    events_left = true
+    while events_left && (events.length < count) do
+      events_left = false
+      provider_events.each_value do |p_events|
+        if p_events.any?
+          events << p_events.shift
+          break if events.length == count
+          events_left ||= p_events.any?
+        end
+      end
+    end
+
+    events
+  end
+
   private
 
   def allowed_url

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -708,4 +708,41 @@ class EventTest < ActiveSupport::TestCase
       e.destroy!
     end
   end
+
+  test 'from_varied_providers' do
+    user = users(:regular_user)
+    provider_1 = content_providers(:goblet)
+    provider_2 = content_providers(:iann)
+    provider_3 = content_providers(:two)
+    e1a = provider_1.events.create!(title: 'Event1a', url: 'https://example.com/events/1a', user: user)
+    e1b = provider_1.events.create!(title: 'Event1b', url: 'https://example.com/events/1b', user: user)
+    e1c = provider_1.events.create!(title: 'Event1c', url: 'https://example.com/events/1c', user: user)
+    e2a = provider_2.events.create!(title: 'Event2a', url: 'https://example.com/events/2a', user: user)
+    e2b = provider_2.events.create!(title: 'Event2b', url: 'https://example.com/events/2b', user: user)
+    e2c = provider_2.events.create!(title: 'Event2c', url: 'https://example.com/events/2c', user: user)
+    e3a = provider_3.events.create!(title: 'Event3a', url: 'https://example.com/events/3a', user: user)
+    e3b = provider_3.events.create!(title: 'Event3b', url: 'https://example.com/events/3b', user: user)
+    e3c = provider_3.events.create!(title: 'Event3c', url: 'https://example.com/events/3c', user: user)
+
+    even_single_mix = Event.from_varied_providers([e1a, e1b, e1c, e2a, e2b, e2c, e3a, e3b, e3c], 3)
+    assert_equal 3, even_single_mix.length
+    assert_equal [e1a, e2a, e3a], even_single_mix, 'Should go through each provider and pick an event'
+
+    even_multi_mix = Event.from_varied_providers([e1a, e1b, e1c, e2a, e2b, e2c, e3a, e3b, e3c], 6)
+    assert_equal 6, even_multi_mix.length
+    assert_equal [e1a, e2a, e3a, e1b, e2b, e3b], even_multi_mix,
+                 'Should go through each provider and pick an event, several times until quota reached'
+
+    skewed_mix = Event.from_varied_providers([e1a, e1b, e1c, e2a], 3)
+    assert_equal 3, skewed_mix.length
+    assert_equal [e1a, e2a, e1b], skewed_mix, 'Should take multiple events from the same provider if needed'
+
+    best_effort_mix = Event.from_varied_providers([e1a, e1b, e1c], 10)
+    assert_equal 3, best_effort_mix.length
+    assert_equal [e1a, e1b, e1c], best_effort_mix,
+                 'Should take all the events from the one provider since that was all that was available'
+
+    empty_mix = Event.from_varied_providers([], 10)
+    assert_empty empty_mix
+  end
 end


### PR DESCRIPTION
**Summary of changes**

- Tweaks the logic for selecting events to display (& adds test)

**Motivation and context**

It was showing an event from 2015:
 
![image](https://github.com/user-attachments/assets/386b8200-d05a-40b6-9ccf-331cb9fa7245)

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
