### PR TITLE
i18n for page footer.

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -15,37 +15,37 @@
 
       <div class="col-sm-4 col-xs-6 text-left">
         <div class="footer-item">
-          <%= link_to "About #{TeSS::Config.site['title_short']}", about_path %>
+          <%= link_to t('footer.about', title: TeSS::Config.site['title_short']), about_path %>
         </div>
         <div class="footer-item">
-          <%= link_to 'Funding & acknowledgements', us_path(anchor: 'funding') %>
+          <%= link_to t('footer.funding'), us_path(anchor: 'funding') %>
         </div>
         <div class="footer-item">
-          <%= link_to 'Privacy', privacy_path %>
+          <%= link_to t('footer.privacy'), privacy_path %>
         </div>
         <% if cookie_consent.required? %>
           <div class="footer-item">
-            <%= link_to 'Cookie preferences', cookies_consent_path %>
+            <%= link_to t('footer.cookie_preferences'), cookies_consent_path %>
           </div>
         <% end %>
       </div>
 
       <div class="col-sm-4 col-xs-6 text-left">
         <div class="footer-item">
-          Version: <code><%= app_version_text -%></code>
+          <%= t('footer.version') %> <code><%= app_version_text -%></code>
         </div>
 
         <div class="footer-item">
-          <%= link_to 'Source code', TeSS::Config.site['repository'], target: '_blank', rel: 'noopener' %>
+          <%= link_to t('footer.source_code'), TeSS::Config.site['repository'], target: '_blank', rel: 'noopener' %>
         </div>
 
         <div class="footer-item">
-          <%= link_to 'API documentation', asset_path('api/json_api', skip_pipeline: true) %>
+          <%= link_to t('footer.api_documentation'), asset_path('api/json_api', skip_pipeline: true) %>
         </div>
 
         <% if TeSS::Config.feature['bioschemas_testing'] %>
           <div class="footer-item">
-            <%= link_to 'Bioschemas testing tool', bioschemas_test_path %>
+            <%= link_to t('footer.bioschemas_testing_tool'), bioschemas_test_path %>
           </div>
         <% end %>
       </div>

--- a/app/views/layouts/_supported_by.erb
+++ b/app/views/layouts/_supported_by.erb
@@ -7,11 +7,11 @@
       <% end %>
     <% end %>
 
-    <%- if I18n.exists?('footer.eu_funding') %>
+    <%- if I18n.exists?('footer.eu_funding_html') %>
       <div class="eu-notice">
         <%= image_tag('elixir/eu-flag.svg') %>
         <div>
-          <%== I18n.t('footer.eu_funding') %>
+          <%== t('footer.eu_funding_html') %>
         </div>
       </div>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -778,7 +778,15 @@ en:
     archived: This %{resource_type} has been archived, its content may no longer be relevant.
     unverified: This %{resource_type} will not be publicly visible until your registration has been approved by an administrator.
   footer:
-    eu_funding: >
+    about: "About %{title}"
+    funding: Funding & acknowledgements
+    privacy: Privacy
+    cookie_preferences: Cookie preferences
+    version: 'Version:'
+    source_code: Source code
+    api_documentation: API documentation
+    bioschemas_testing_tool: Bioschemas testing tool
+    eu_funding_html: >
       TeSS has received funding from the European Union’s Horizon 2020 research and innovation programme under grant agreement No. <a href="https://cordis.europa.eu/project/rcn/198519_en.html", target="_blank">676559</a>.
   time:
     formats:


### PR DESCRIPTION
**Summary of changes**

Ensure that the page footers fully go through i18n.

Included: make the EU Funding statement go through the t() view helper (and flagged as having html content, which ensures they are escaped properly).

**Motivation and context**

Trying to make TeSS more fully i18n capable.
 
**Screenshots**

Looks the same as before.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
