### PR TITLE
Limit keywords to 20, and only display first 10 on index pages

### DIFF
--- a/app/helpers/materials_helper.rb
+++ b/app/helpers/materials_helper.rb
@@ -139,10 +139,14 @@ where each topic has one competency level for all its materials. \n\n\
       tags |= resource.send(field) if resource.respond_to?(field)
     end
 
+    limit_exceeded = limit && (tags.length > limit)
     tags = tags.first(limit) if limit
 
-    tags.map do |tag|
+    elements = tags.map do |tag|
       content_tag(:span, tag, class: 'label label-info')
-    end.join(' ').html_safe
+    end
+    elements << '&hellip;' if limit_exceeded
+
+    elements.join(' ').html_safe
   end
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -27,6 +27,7 @@ class Collection < ApplicationRecord
   after_commit :index_items, if: :title_previously_changed?
 
   validates :title, presence: true
+  validates :keywords, length: { maximum: 20 }
 
   clean_array_fields(:keywords)
   update_suggestions(:keywords)

--- a/app/models/content_provider.rb
+++ b/app/models/content_provider.rb
@@ -32,8 +32,8 @@ class ContentProvider < ApplicationRecord
 
   # Validate the URL is in correct format via valid_url gem
   validates :url, url: true
-
   validates :content_provider_type, presence: true, inclusion: { in: PROVIDER_TYPE }
+  validates :keywords, length: { maximum: 20 }
 
   clean_array_fields(:keywords)
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -137,6 +137,7 @@ class Event < ApplicationRecord
   validates :longitude, numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180, allow_nil: true }
   # validates :duration, format: { with: /\A[0-9][0-9]:[0-5][0-9]\z/, message: "must be in format HH:MM" }, allow_blank: true
   validates :presence, inclusion: { in: presences.keys, allow_blank: true }
+  validates :keywords, length: { maximum: 20 }
   validate :allowed_url
   clean_array_fields(:keywords, :fields, :event_types, :target_audience,
                      :eligibility, :host_institutions, :sponsors)

--- a/app/models/learning_path.rb
+++ b/app/models/learning_path.rb
@@ -75,6 +75,7 @@ class LearningPath < ApplicationRecord
   after_validation :normalize_order
 
   validates :title, :description, presence: true
+  validates :keywords, length: { maximum: 20 }
 
   clean_array_fields(:keywords, :contributors, :authors, :target_audience)
   update_suggestions(:keywords, :contributors, :authors, :target_audience)

--- a/app/models/learning_path_topic.rb
+++ b/app/models/learning_path_topic.rb
@@ -22,6 +22,7 @@ class LearningPathTopic < ApplicationRecord
   after_validation :normalize_order
 
   validates :title, presence: true
+  validates :keywords, length: { maximum: 20 }
 
   clean_array_fields(:keywords)
   update_suggestions(:keywords)

--- a/app/models/material.rb
+++ b/app/models/material.rb
@@ -103,6 +103,7 @@ class Material < ApplicationRecord
   validates :title, :description, :url, presence: true
   validates :url, url: true
   validates :other_types, presence: true, if: Proc.new { |m| m.resource_type.include?('other') }
+  validates :keywords, length: { maximum: 20 }
 
   clean_array_fields(:keywords, :fields, :contributors, :authors,
                      :target_audience, :resource_type, :subsets)

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -62,6 +62,7 @@ class Workflow < ApplicationRecord
   auto_strip_attributes :title, squish: false
 
   validates :title, presence: true
+  validates :keywords, length: { maximum: 20 }
 
   clean_array_fields(:keywords, :contributors, :authors, :target_audience)
 

--- a/app/views/materials/_material.html.erb
+++ b/app/views/materials/_material.html.erb
@@ -28,7 +28,7 @@
 
       <div class="font-size-lg"><%= display_difficulty_level(material) %></div>
 
-      <%= keywords_and_topics(material) %>
+      <%= keywords_and_topics(material, limit: 10) %>
     </div>
 
     <%= item_comment(collection_item) if defined? collection_item %>

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -708,4 +708,16 @@ class EventTest < ActiveSupport::TestCase
       e.destroy!
     end
   end
+
+  test 'validates keywords length' do
+    event = events(:one)
+    keywords = 20.times.map { |i| "keyword_#{i}" }
+    event.keywords = keywords
+    assert event.valid?
+
+    event.keywords = keywords + ['extra_keyword']
+
+    refute event.valid?
+    assert event.errors.added?(:keywords, :too_long, count: 20)
+  end
 end


### PR DESCRIPTION
**Summary of changes**

- Add a hard limit of 20 keywords.
- Only display first 10 keywords on index pages.

**Motivation and context**

Some scraped content had an excessive amount of keywords and it was overflowing. Agreed in the TeSS Club that having a large number of keywords is not realistic or useful.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
