### PR TITLE
Remove source URL validation in scraper

### DIFF
--- a/lib/scraper.rb
+++ b/lib/scraper.rb
@@ -225,32 +225,8 @@ class Scraper
         log t('scraper.messages.invalid', error_message: "#{error.full_message}: #{source.send(error.attribute)}"), 2
       end
     end
-    valid_url = validate_url(source.url, source.token)
 
-    valid && valid_url
-  end
-
-  def validate_url(input, token)
-    result = true
-    eventbrite_api = 'https://www.eventbriteapi.com/v3/'
-    begin
-      response = if input.starts_with?(eventbrite_api) and !token.nil?
-                   Net::HTTP.get_response(URI.parse(input + '/events/?token=' + token))
-                 else
-                   Net::HTTP.get_response(URI.parse(input))
-                 end
-
-      case response
-      when Net::HTTPSuccess then true
-      when Net::HTTPOK then true
-      else raise 'Invalid URL'
-      end
-    rescue StandardError
-      log t('scraper.messages.invalid', error_message: "#{t('scraper.messages.url_not_accessible')}: #{input}"), 2
-      result = false
-    end
-
-    result
+    valid
   end
 
   def log(message, level)

--- a/test/config/test_ingestion_bad.yml
+++ b/test/config/test_ingestion_bad.yml
@@ -4,6 +4,6 @@ username: Bob
 sources:
   - id: 1
     provider: 'Dummy Provider'            # content provider's title - not found
-    url: https://app.com/event.csv      # the root URL required to access the source
+    url: https://app.com/events.csv      # the root URL required to access the source
     method: csv                         # one of 'csv', 'api', 'html'
     enabled: true

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -36,8 +36,10 @@ class ApplicationControllerTest < ActionController::TestCase
     get :test_url, params: { url: 'http://notrealhost.goldfish', format: :json }
     assert_equal 'Could not access the given URL', JSON.parse(response.body)['message']
 
-    get :test_url, params: { url: 'http://127.0.0.1', format: :json }
-    assert_equal 'Could not access the given URL', JSON.parse(response.body)['message']
+    with_net_connection do
+      get :test_url, params: { url: 'http://127.0.0.1', format: :json }
+      assert_equal 'Could not access the given URL', JSON.parse(response.body)['message']
+    end
   end
 
 end

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -84,8 +84,10 @@ class ProfileTest < ActiveSupport::TestCase
     refute profile.errors.added?(:website, 'is blocked')
 
     # private address
-    refute profile.update(website: 'http://127.0.0.1')
-    assert profile.errors.added?(:website, 'is not accessible')
+    with_net_connection do # Allow request through to be caught by private_address_check
+      refute profile.update(website: 'http://127.0.0.1')
+      assert profile.errors.added?(:website, 'is not accessible')
+    end
 
     # address that times out
     refute profile.update(website: 'http://slowhost.com')

--- a/test/models/source_test.rb
+++ b/test/models/source_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class SourceTest < ActiveSupport::TestCase
-
   setup do
     @user = users :scraper_user
     assert_not_nil @user
@@ -238,7 +237,7 @@ class SourceTest < ActiveSupport::TestCase
     User.current_user = source.user
 
     assert_difference('PublicActivity::Activity.count', 2) do
-      source.url = 'https://icalendars.golf/calendar123.ical'
+      source.url = 'https://pawsey.org.au/event/pawsey-intern-showcase-2022/?ical=true'
       source.method = 'ical'
       source.save!
     end

--- a/test/unit/image_attachment_test.rb
+++ b/test/unit/image_attachment_test.rb
@@ -103,12 +103,14 @@ class ImageAttachmentTest < ActiveSupport::TestCase
   end
 
   test 'should not permit internal image URL address' do
-    provider = content_providers(:goblet)
-    provider.image_url = 'http://127.0.0.1/image.png'
+    with_net_connection do # Allow request through to be caught by private_address_check
+      provider = content_providers(:goblet)
+      provider.image_url = 'http://127.0.0.1/image.png'
 
-    refute provider.save
+      refute provider.save
 
-    assert_equal 1, provider.errors[:image_url].length
-    assert provider.errors[:image_url].first.include?('could not be accessed')
+      assert_equal 1, provider.errors[:image_url].length
+      assert provider.errors[:image_url].first.include?('could not be accessed')
+    end
   end
 end

--- a/test/unit/ingestors/scraper_test.rb
+++ b/test/unit/ingestors/scraper_test.rb
@@ -178,8 +178,6 @@ class ScraperTest < ActiveSupport::TestCase
     # check validation errors
     error_message = 'Provider not found: Dummy Provider'
     assert logfile_contains(logfile, error_message), 'Error message not found: ' + error_message
-    error_message = 'URL not accessible: https://dummy.com/events.csv'
-    assert logfile_contains(logfile, error_message), 'Error message not found: ' + error_message
     error_message = 'Method is invalid: xtc'
     assert logfile_contains(logfile, error_message), 'Error message not found: ' + error_message
   end


### PR DESCRIPTION
**Summary of changes**

- Removes the `validate_url` call when running a source through a `Scraper`.
- Ensures no external network requests are made when running tests.
- Adds a `with_net_connection` test method to allow real network calls in tests if needed (currently used to test `private_address_check` is working).

**Motivation and context**

A user created a source with a URL that returned a 301 redirect. This worked fine when testing, but was considered invalid when running through the scraper. The URL format is already validated when creating a source, and any issues when resolving the URL should be raised when running the actual `Ingestor`.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
