### PR TITLE
Ensure collaborators can see private collections

### DIFF
--- a/app/policies/collection_policy.rb
+++ b/app/policies/collection_policy.rb
@@ -5,7 +5,7 @@ class CollectionPolicy < ResourcePolicy
   end
 
   def show?
-    (!@record.from_unverified_or_rejected? && @record.public?) || manage?
+    (!@record.from_unverified_or_rejected? && @record.public?) || update?
   end
 
   def curate?

--- a/test/controllers/collections_controller_test.rb
+++ b/test/controllers/collections_controller_test.rb
@@ -12,6 +12,7 @@ class CollectionsControllerTest < ActionController::TestCase
       description: 'New description'
     }
   end
+
   #INDEX TESTS
   test 'should get index' do
     get :index
@@ -77,6 +78,14 @@ class CollectionsControllerTest < ActionController::TestCase
   #logged in but insufficient permissions = ERROR
   test 'should get edit for collection owner' do
     sign_in @collection.user
+    get :edit, params: { id: @collection }
+    assert_response :success
+  end
+
+  test 'should get edit for collection collaborator' do
+    collaborator = users(:another_regular_user)
+    @collection.collaborators << collaborator
+    sign_in collaborator
     get :edit, params: { id: @collection }
     assert_response :success
   end
@@ -507,9 +516,18 @@ class CollectionsControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
-  test 'should allow access to private collections if privileged' do
+  test 'should allow access to private collections if privileged as owner' do
     sign_in users(:regular_user)
     get :show, params: { id: collections(:secret_collection) }
+    assert_response :success
+  end
+
+  test 'should allow access to private collections if privileged as collaborator' do
+    collection = collections(:secret_collection)
+    collaborator = users(:another_regular_user)
+    collection.collaborators << collaborator
+    sign_in collaborator
+    get :show, params: { id: collection }
     assert_response :success
   end
 


### PR DESCRIPTION
**Summary of changes**

- Fixes collection policy which was only allowing "managers" to see the collection.

**Motivation and context**

User who was a collaborator on a private collection could not view it, although could load the edit page and make changes.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
