### PR TITLE
Configure I18n from tess.yml

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,3 +12,4 @@ The following people have contributed to the TeSS codebase:
 * Daan van Vugt <dvanvugt@ignitioncomputing.com>
 * Xènia Pérez Sitjà <https://orcid.org/0000-0002-7166-0183>
 * Ivan Kuzmin <ivan.kuzmin@ut.ee>
+* Servilio Afre Puentes <afrepues@sharcnet.ca>

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,6 +2,8 @@ require_relative 'boot'
 
 require 'rails/all'
 
+require_relative '../lib/tess/i18n'
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
@@ -38,6 +40,36 @@ module TeSS
       config.tess
         .dig(:i18n, :default_locale)
         .to_sym
+
+    case config.tess.dig(:i18n, :fallback_strategy)
+    when 'manual'
+      if config.tess.dig(:i18n, :fallbacks).present?
+        config.i18n.fallbacks =
+          config.tess.dig(:i18n, :fallbacks)
+      end
+    when 'simple',  'rfc4646'
+      I18n.backend.class.include(I18n::Backend::Fallbacks)
+      # Detect if any locale specifies any detail beyond primary
+      # language subtag (e.g.: en-CA).
+      any_has_subtags =
+        config.tess
+          .dig(:i18n, :available_locales)
+          .any? &I18n::Locale::Tag.method(:has_subtags?)
+      if any_has_subtags
+        # This is necessary for RFC4646-based fallbacks to work, as
+        # I18n won't use resolve l10n keys from fallback locales that
+        # are not in the `available_locales`.
+        config.i18n.available_locales +=
+          config.tess.dig(:i18n, :available_locales)
+            .map {|locale| I18n.fallbacks[locale] - [locale.to_sym] }
+            .flatten
+      end
+      if config.tess.dig(:i18n, :fallback_strategy) == 'rfc4646'
+        I18n::Locale::Tag.implementation = I18n::Locale::Tag::Rfc4646
+      end
+    else
+      raise "Bad fallback strategy: #{config.tess.dig(:i18n, :fallback_strategy)}"
+    end
 
     config.active_record.yaml_column_permitted_classes = [
       Symbol, Date, Time, ActiveSupport::TimeWithZone, ActiveSupport::TimeZone,

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,8 +30,14 @@ module TeSS
 
     # locales
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', 'overrides', '**', '*.{rb,yml}')] unless Rails.env.test?
-    config.i18n.available_locales = [:en]
-    config.i18n.default_locale = :en
+    config.i18n.available_locales =
+      config.tess
+        .dig(:i18n, :available_locales)
+        .map(&:to_sym)
+    config.i18n.default_locale =
+      config.tess
+        .dig(:i18n, :default_locale)
+        .to_sym
 
     config.active_record.yaml_column_permitted_classes = [
       Symbol, Date, Time, ActiveSupport::TimeWithZone, ActiveSupport::TimeZone,

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -97,10 +97,6 @@ Rails.application.configure do
     protocol: URI.parse(TeSS::Config.base_url).scheme
   }
 
-  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
-  # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = [I18n.default_locale]
-
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -48,10 +48,6 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 
   config.action_mailer.asset_host = TeSS::Config.base_url
-
-  # LanguageDictionary test does some French testing
-  config.i18n.available_locales = [:en, :fr]
-  config.i18n.default_locale = :en
 end
 
 # Override secrets with test configuration from test/config

--- a/config/tess.example.yml
+++ b/config/tess.example.yml
@@ -25,6 +25,67 @@ default: &default
       - en
     # Sets the default locale of the application.
     default_locale: en
+
+    # Fallbacks configuration. Defaults match default Rails
+    # behaviour. Set `fallbacks_strategy` to a different value to
+    # `manual` when including a locale with multiple subtags in
+    # `available_locales`, and would like to keys to be resolved from
+    # translations catalogues from the parent locales. Example, with
+    # the following configuration:
+    #
+    #   - available_locales:  [ 'de-Latn-DE' ]
+    #   - default_locale: de-Latn-DE
+    #   - fallbacks_strategy: simple
+    #
+    # Translations will be searched in catalogues for `de-Latn-DE`,
+    # `de-Latn` and `de` in that order.
+    #
+    # Valid values:
+    #
+    # - manual
+    #
+    #     Just pass the value of `fallbacks` to Rails.
+    #
+    # - simple
+    #
+    #     Enable use of fallbacks and add the fallbacks of locales in
+    #     `tess.i18n.available_locales` to
+    #     `config.i18n.available_locales` to make sure that available
+    #     translations in any of them are used by Rails. This allows
+    #     to have region-specific locale but still use translations
+    #     available in the base language, e.g.: with locale en-CA
+    #     translations from en-CA and en will be used.
+    #
+    # - rfc4646
+    #
+    #     Like the simple strategy, but uses the RFC4646-compliant
+    #     parser from I18n. Only necessary if you are using locales
+    #     with private-use subtags.
+    #
+    # See:
+    #
+    # - I18n wiki, Fallbacks
+    #   https://github.com/ruby-i18n/i18n/wiki/Fallbacks
+    #
+    # - Configuring Rails applications, §3.6 Configuring i18n
+    #   https://guides.rubyonrails.org/v7.0/configuring.html#configuring-i18n
+    #
+    # - I18n::Locale::Tag:Rfc4646 source
+    #   https://github.com/ruby-i18n/i18n/blob/3b65f6548245411bc9802f5a547954d370b57821/lib/i18n/locale/tag/rfc4646.rb
+    #
+    # - RFC4646, Private Use Subtags
+    #   https://datatracker.ietf.org/doc/html/rfc4646#section-2.2.7
+    fallback_strategy: manual
+
+    # The value of this option is passed directly to
+    # `config.i18n.fallbacks` when `fallback_strategy` is set to
+    # `manual`.
+    #
+    # See:
+    #
+    # - Configuring Rails applications, §3.6 Configuring i18n
+    #   https://guides.rubyonrails.org/v7.0/configuring.html#configuring-i18n
+    #fallbacks: ...
   site:
     title: 'TeSS (Training eSupport System)'
     title_short: TeSS

--- a/config/tess.example.yml
+++ b/config/tess.example.yml
@@ -19,6 +19,12 @@ default: &default
   # - gb
   sentry_dsn:
   csp_report_uri: 
+  i18n:
+    # Defines the locales available in the application.
+    available_locales:
+      - en
+    # Sets the default locale of the application.
+    default_locale: en
   site:
     title: 'TeSS (Training eSupport System)'
     title_short: TeSS

--- a/docker/tess.docker-test.yml
+++ b/docker/tess.docker-test.yml
@@ -12,6 +12,10 @@ default: &default
   require_cookie_consent: true
   blocked_domains:
     - !ruby/regexp '/bad-domain\.example/'
+  i18n:
+    available_locales:
+      - en
+    default_locale: en
   site:
     title: 'TeSS (Training eSupport System)'
     title_short: TeSS

--- a/docker/tess.docker-test.yml
+++ b/docker/tess.docker-test.yml
@@ -16,6 +16,7 @@ default: &default
     available_locales:
       - en
     default_locale: en
+    fallback_strategy: manual
   site:
     title: 'TeSS (Training eSupport System)'
     title_short: TeSS

--- a/lib/tess/i18n.rb
+++ b/lib/tess/i18n.rb
@@ -1,0 +1,14 @@
+module I18n
+  module Locale
+    module Tag
+      class << self
+        def has_subtags?(locale)
+          I18n::Locale::Tag::Rfc4646
+            .parser.match(locale)
+            .compact
+            .length > 1
+        end
+      end
+    end
+  end
+end

--- a/test/config/test_tess.yml
+++ b/test/config/test_tess.yml
@@ -12,6 +12,11 @@ default: &default
     - !ruby/regexp '/bad-domain\.example/'
   identifiers_url: "http://example.com/identifiers/"
   identifiers_prefix: banana
+  i18n:
+    available_locales:
+      - en
+      - fr
+    default_locale: en
   site:
     title: 'TeSS Test Instance'
     title_short: 'TTI'

--- a/test/config/test_tess.yml
+++ b/test/config/test_tess.yml
@@ -17,6 +17,7 @@ default: &default
       - en
       - fr
     default_locale: en
+    fallback_strategy: manual
   site:
     title: 'TeSS Test Instance'
     title_short: 'TTI'


### PR DESCRIPTION
**Summary of changes**

The main changes allow for configuring I18n from tess.yml.

**Motivation and context**

This allows each deployment of TeSS to configure I18n without having to maintain local code customizations. This in turn is motivated by requirements of the National Training Discovery portal project of the Digital Research Alliance of Canada.

**Screenshots**

No visible changes.

**Checklist**

- [X] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [X] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
