### PR TITLE
Easier selection of user's own topics when making learning paths

### DIFF
--- a/app/assets/javascripts/autocompleters.js
+++ b/app/assets/javascripts/autocompleters.js
@@ -107,11 +107,12 @@ var Autocompleters = {
                     if (opts.singleton) {
                         inputElement.hide();
                     }
+
+                    const event = new CustomEvent('autocompleters:added', {  bubbles: true, detail: { object: obj } });
+                    listElement[0].dispatchEvent(event);
                 }
 
                 $(this).val('').focus();
-                const event = new CustomEvent('autocompleters:added', {  bubbles: true, detail: { object: obj } });
-                listElement[0].dispatchEvent(event);
             },
             onSearchStart: function (query) {
                 inputElement.addClass("loading");

--- a/app/assets/javascripts/collections.js
+++ b/app/assets/javascripts/collections.js
@@ -33,6 +33,7 @@ var Collections = {
             $(this).on('autocompleters:added', function () {
                 // Re-compute orders after new item added.
                 Collections.recalculateOrder(this);
+                Collections.displayEmptyText(list);
             });
 
             $(this).on('click', '[data-role="delete-collection-item"]', function (e) {
@@ -46,6 +47,7 @@ var Collections = {
                     // Re-compute orders after item removed.
                     item.remove();
                     Collections.recalculateOrder(list);
+                    Collections.displayEmptyText(list);
                 } else {
                     if (checkbox.is(':checked')) {
                         checkbox.prop('checked', false);
@@ -63,6 +65,7 @@ var Collections = {
 
             // Calculate initial order - order from database may have gaps if items were deleted.
             Collections.recalculateOrder(list);
+            Collections.displayEmptyText(list);
         });
     },
 
@@ -73,5 +76,16 @@ var Collections = {
             li.querySelector('.item-order-label').innerText = order;
             order++;
         });
+    },
+
+    displayEmptyText: function (listEl) {
+        const list = $(listEl)
+        if (!list.children('li').length) {
+            if (!$('span.empty', list).length) {
+                list.append('<span class="empty">Empty</span>');
+            }
+        } else {
+            list.children('span').remove();
+        }
     }
 }

--- a/app/assets/javascripts/learning_paths.js
+++ b/app/assets/javascripts/learning_paths.js
@@ -13,5 +13,35 @@ var LearningPaths = {
                 $('.learning-path-topic-title', topic).click();
             }
         }
+
+        $("[data-role='user-lp-topics-select']").change(LearningPaths.selectTopic);
+    },
+
+    selectTopic: function () {
+        const element = $(this);
+        const option = $(this).find('option:selected');
+        const id = parseInt(option.val());
+        if (!id) {
+            return true;
+        }
+        const title = option.text();
+        const listElement = $("[data-role='collection-items-group']").find('.collection-items');
+        if (!$("[data-id='Topic-" + id + "']", listElement).length) {
+            const obj = { item: {
+                    id: null,
+                    title: title,
+                    url: option.data('url'),
+                    resource_id: id,
+                    resource_type: 'Topic'
+                },
+                prefix: 'learning_path[topic_links_attributes]'
+            };
+
+            listElement.append(HandlebarsTemplates['autocompleter/learning_path_topic'](obj));
+            const event = new CustomEvent('autocompleters:added', {  bubbles: true, detail: { object: obj } });
+            listElement[0].dispatchEvent(event);
+        }
+
+        element.val('').focus();
     }
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1009,3 +1009,8 @@ td.day .calendar-text {
   max-height: 20pc;
   overflow-y: scroll;
 }
+
+.draggable--over {
+  opacity: 0.7;
+  background: $state-success-bg;
+}

--- a/app/assets/stylesheets/collection.scss
+++ b/app/assets/stylesheets/collection.scss
@@ -30,6 +30,7 @@
     }
 
     .collection-item-handle {
+      cursor: grab;
       color: $text-muted;
       padding: 0 15px;
       user-select: none;

--- a/app/views/collections/_collection_items_form.erb
+++ b/app/views/collections/_collection_items_form.erb
@@ -25,9 +25,7 @@
 <div class="form-group">
   <%= f.label field_name %>
 
-  <p class="help-block">
-    Re-order items by clicking and dragging the icon on the left-hand side.
-  </p>
+  <p class="help-block"><%= t('collections.hints.reorder') %></p>
 
   <%= content_tag(:div, data: data) do %>
       <%= content_tag :script, json.html_safe, type: 'application/json', data: { role: 'autocompleter-existing' } %>

--- a/app/views/collections/_form.html.erb
+++ b/app/views/collections/_form.html.erb
@@ -10,8 +10,7 @@
       <%= render partial: 'common/image_form', locals: { form: f } %>
     </div>
 
-  <%= f.input :public,
-              hint: "Un-ticking this box will hide this collection from anyone who isn't the creator or a collaborator." %>
+  <%= f.input :public, hint: t('collections.hints.public') %>
 
     <%= f.multi_input :keywords %>
 

--- a/app/views/learning_paths/_form.html.erb
+++ b/app/views/learning_paths/_form.html.erb
@@ -89,15 +89,13 @@
         prefix: form_field_name }
     end.to_json
 
-    placeholder_text = "Add a new topic"
+    placeholder_text = t('learning_paths.form.search_for_topics')
   %>
 
   <div class="form-group">
-    <%= f.label 'Topics' %>
+    <%= f.label t('features.learning_path_topics.long') %>
 
-    <p class="help-block">
-      Re-order items by clicking and dragging the icon on the left-hand side.
-    </p>
+    <p class="help-block"><%= t('collections.hints.reorder') %></p>
 
     <%= content_tag(:div, data: data) do %>
       <%= content_tag :script, json.html_safe, type: 'application/json', data: { role: 'autocompleter-existing' } %>
@@ -106,6 +104,15 @@
         <%# Populated via javascript from the JSON above %>
       </ul>
 
+      <% user_topics = current_user.learning_path_topics.order(title: :asc) %>
+      <% if user_topics.any? %>
+        <h6><%= t('learning_paths.form.my_topics') %></h6>
+        <%= select_tag(nil, options_for_select(user_topics.map { |t| [t.title, t.id, 'data-url': learning_path_topic_url(t)] }),
+                       prompt: t('learning_paths.form.select_topic'), 'data-role': 'user-lp-topics-select', class: 'form-control') %>
+
+        <h6><%= t('learning_paths.form.all_topics') %></h6>
+      <% end %>
+
       <input type="text" data-role="autocompleter-input" autocomplete="off" class="form-control"
              placeholder="<%= placeholder_text %>">
     <% end %>
@@ -113,8 +120,7 @@
 
   <hr>
 
-  <%= f.input :public,
-              hint: "Un-ticking this box will hide this learning path from anyone who isn't the creator or a collaborator." %>
+  <%= f.input :public, hint: t('learning_paths.hints.public') %>
 
   <!-- Form Buttons -->
   <div class="form-group">

--- a/app/views/workflows/_form.html.erb
+++ b/app/views/workflows/_form.html.erb
@@ -44,11 +44,9 @@
         <%= f.multi_input :contributors, suggestions_url: people_autocomplete_suggestions_path %>
       <% end %>
 
-      <%= f.input :hide_child_nodes,
-                  hint: 'Ticking this box will hide child nodes from the diagram until their parent node is clicked.' %>
+      <%= f.input :hide_child_nodes, hint: t('workflows.hints.hide_child_nodes') %>
 
-      <%= f.input :public,
-                  hint: "Un-ticking this box will hide this workflow from anyone who isn't the creator or a collaborator." %>
+      <%= f.input :public, hint: t('workflows.hints.public') %>
     </div>
   </div>
   <div class="row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -671,9 +671,15 @@ en:
       resource_type: 'Select the type of resource that best matches the learning path. '
       url: 'Preferred URL to direct people to your learning path landing page.'
       version: 'Indicate the current version of the learning path.'
+      public: Un-ticking this box will hide this learning path from anyone who isn't the creator or a collaborator.
     next_topic: Next topic
     next_item: Next
     end_of: End of learning path
+    form:
+      my_topics: My topics
+      all_topics: All topics
+      select_topic: Select a topic...
+      search_for_topics: Search for topics...
   profile:
     user:
       disclaimer: >
@@ -843,6 +849,13 @@ en:
     show:
       curate_materials: "Curate materials"
       curate_events: "Curate events"
+    hints:
+      reorder: Re-order items by clicking and dragging the icon on the left-hand side.
+      public: Un-ticking this box will hide this collection from anyone who isn't the creator or a collaborator.
+  workflows:
+    hints:
+      hide_child_nodes: Ticking this box will hide child nodes from the diagram until their parent node is clicked.
+      public: Un-ticking this box will hide this workflow from anyone who isn't the creator or a collaborator.
   menu:
     user:
       my_profile: 'My profile'


### PR DESCRIPTION
**Summary of changes**

- Adds a dropdown list of user's own topics in addition to search field.
- Moves some hard-coded text into translation files.

**Motivation and context**

Generally users want to add their own topics to a learning path.
 
**Screenshots**

![image](https://github.com/user-attachments/assets/c7b01bf9-cdcd-4e72-8b83-2e2babba3756)

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
