### PR TITLE
Add a rake task that prioritizes solr reindexing to minimize downtime

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -69,7 +69,7 @@ To run a specific test, you can override the command being passed:
 
 To force Solr to reindex all documents, you can run the following command:
 
-    docker-compose exec app bundle exec rake sunspot:reindex
+    docker-compose exec app bundle exec rake tess:reindex
 
 ### Additional development commands
 
@@ -134,4 +134,4 @@ Precompile the assets, necessary if any CSS/JS/images are changed after building
 
 Reindex Solr:
 
-    docker-compose -f docker-compose-prod.yml exec app bundle exec rake sunspot:reindex
+    docker-compose -f docker-compose-prod.yml exec app bundle exec rake tess:reindex

--- a/docs/install.md
+++ b/docs/install.md
@@ -154,7 +154,7 @@ Next, create a collection for TeSS to use (assuming TeSS is checked out at `/hom
 If you ever need to re-index your TeSS data, for example if you have existing data in your TeSS database and are using 
 a new collection, you can run the following command:
 
-    bundle exec rake seek:reindex_all
+    bundle exec rake tess:reindex
 
 ## Redis/Sidekiq
 


### PR DESCRIPTION
**Summary of changes**

- Adds `tess:reindex` which indexes upcoming events and materials before other resources.

**Motivation and context**

When running `sunspot:reindex` it will drop the index of each model and then reindex every resource, which can lead to long periods of time where the index pages are blank while it indexes e.g. thousands of expired events.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
