### PR TITLE
Make view content related to subscriptions go through i18n.

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -14,7 +14,7 @@ class SubscriptionsController < ApplicationController
     @subscription = current_user.subscriptions.build(subscription_params)
 
     if @subscription.save
-      flash[:notice] = 'Subscription successfully created.'
+      flash[:notice] = t('subscriptions.created')
       respond_to do |format|
         format.html { redirect_to subscriptions_path }
       end
@@ -29,13 +29,14 @@ class SubscriptionsController < ApplicationController
   def destroy
     authorize @subscription.user, :manage?
     if @subscription.destroy
-      flash[:notice] = 'Subscription cancelled.'
+      flash[:notice] = t('subscriptions.cancelled')
       respond_to do |format|
         format.html { redirect_to subscriptions_path }
       end
     else
       respond_to do |format|
-        format.html { render plain: 'There was a problem unsubscribing.', status: :unprocessable_entity }
+        format.html { render plain: t('subscriptions.problem_unsubscribing'),
+                             status: :unprocessable_entity }
       end
     end
   end
@@ -47,7 +48,8 @@ class SubscriptionsController < ApplicationController
       end
     else
       respond_to do |format|
-        format.html { render plain: 'Invalid code', status: :unprocessable_entity }
+        format.html { render plain: t('subscriptions.invalid_code'),
+                             status: :unprocessable_entity }
       end
     end
   end
@@ -78,6 +80,7 @@ class SubscriptionsController < ApplicationController
 
   def set_breadcrumbs
     add_base_breadcrumbs('users')
-    @breadcrumbs += [{ name: current_user.name, url: user_path(current_user) }, { name: 'Subscriptions' }]
+    @breadcrumbs += [{ name: current_user.name, url: user_path(current_user) },
+                     { name: t('subscriptions.breadcrumb') }]
   end
 end

--- a/app/helpers/subscriptions_helper.rb
+++ b/app/helpers/subscriptions_helper.rb
@@ -2,7 +2,8 @@
 module SubscriptionsHelper
 
   def frequency_options_for_select
-    options_for_select(Subscription::FREQUENCY.map { |k| [k[:key].to_s.humanize, k[:key]] })
+    options_for_select(Subscription::FREQUENCY.map { |k| [t("subscriptions.frequency_options.#{k[:key]}"),
+                                                          k[:key]] })
   end
 
   def subscription_results_path(sub)

--- a/app/views/subscriptions/_subscribe_button.html.erb
+++ b/app/views/subscriptions/_subscribe_button.html.erb
@@ -7,20 +7,20 @@
 <% if show_calendar_sub || show_email_sub || show_rss_sub %>
   <div class="btn-group">
     <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-      Subscribe <span class="caret"></span>
+      <%= t('subscriptions.button.title') %> <span class="caret"></span>
     </button>
     <ul class="dropdown-menu">
       <% if show_email_sub %>
         <li>
           <a href="#" data-toggle="modal" data-target="#subscribe-email-modal">
-            <i class="fa fa-envelope-o"></i> Subscribe via email
+            <i class="fa fa-envelope-o"></i> <%= t('subscriptions.button.via_email') %>
           </a>
         </li>
       <% end %>
       <% if show_calendar_sub %>
         <li>
           <a href="#" data-toggle="modal" data-target="#subscribe-calendar-modal">
-            <i class="fa fa-calendar-o"></i> Add to calendar
+            <i class="fa fa-calendar-o"></i> <%= t('subscriptions.button.add_to_calendar') %>
           </a>
         </li>
       <% end %>
@@ -28,11 +28,12 @@
         <% rss_url = url_for(search_and_facet_params.merge(format: :rss, only_path: false)) %>
         <li>
           <a href="#" data-toggle="modal" data-target="#subscribe-rss-modal">
-            <i class="fa fa-rss"></i> Subscribe to RSS feed
+            <i class="fa fa-rss"></i> <%= t('subscriptions.button.to_rss') %>
           </a>
         </li>
         <% content_for :extra_head do %>
-          <link rel="alternate" type="application/rss+xml" title="Events RSS feed" href="<%= rss_url %>" />
+          <link rel="alternate" type="application/rss+xml"
+                title="<%= t('subscriptions.button.events_rss_feed') %>" href="<%= rss_url %>" />
         <% end %>
       <% end %>
     </ul>
@@ -45,17 +46,19 @@
             <div class="modal-header">
               <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                 <span aria-hidden="true">&times;</span></button>
-              <h4 class="modal-title" id="subscribe-email-modal-title">Email Subscription</h4>
+              <h4 class="modal-title" id="subscribe-email-modal-title">
+                <%= t('subscriptions.button.email_title') %></h4>
             </div>
 
             <div class="modal-body">
               <%= form_tag(subscriptions_path(search_and_facet_params)) do %>
                   <%= hidden_field_tag('subscription[subscribable_type]', type) %>
                   <div class="form-group">
-                    <label for="frequency">Frequency</label>
-                    <%= select_tag('subscription[frequency]', frequency_options_for_select, class: 'form-control', autocomplete: 'off') %>
+                    <label for="frequency"><%= t('subscriptions.button.frequency') %></label>
+                    <%= select_tag('subscription[frequency]', frequency_options_for_select,
+                                   class: 'form-control', autocomplete: 'off') %>
                   </div>
-                  <%= submit_tag('Subscribe', class: 'btn btn-primary') %>
+                  <%= submit_tag(t('subscriptions.button.submit_button'), class: 'btn btn-primary') %>
               <% end %>
             </div>
           </div>

--- a/app/views/subscriptions/_subscribe_to_calendar_modal.html.erb
+++ b/app/views/subscriptions/_subscribe_to_calendar_modal.html.erb
@@ -2,30 +2,31 @@
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+        <button type="button" class="close" data-dismiss="modal"
+                aria-label="<%= t('subscriptions.modal.close') %>">
           <span aria-hidden="true">&times;</span></button>
-        <h4 class="modal-title" id="subscribe-modal-title">Subscribe to Filter</h4>
+        <h4 class="modal-title" id="subscribe-modal-title">
+          <%= t('subscriptions.modal.subscribe_to_filter') %>
+        </h4>
       </div>
 
       <div class="modal-body">
-        <label for="calendar-link">URL</label>
+        <label for="calendar-link"><%= t('subscriptions.modal.url') %></label>
         <div class="input-group input-group-lg">
           <input id="calendar-link" type="text" class="form-control" value="<%= events_url({ format: :ics }.merge(search_and_facet_params)) -%>" readonly>
           <span class="input-group-btn">
-            <button class="btn btn-default clipboard-btn" type="button" data-clipboard-target="#calendar-link" title="Click to copy">
+            <button class="btn btn-default clipboard-btn" type="button"
+                    data-clipboard-target="#calendar-link"
+                    title="<%= t('subscriptions.modal.click_to_copy') %>">
               <i class="fa fa-clipboard" aria-hidden="true"></i>
             </button>
           </span>
         </div>
-        <h3>Importing into Google Calendar</h3>
-        <p>
-        In the left-hand column of the <a href="https://calendar.google.com/calendar" target="_blank" rel="noopener">Google Calendar</a> main view,
-        click the arrow to the right of "Other calendars" and click "Add by URL". In the form that appears, paste in the URL from the box above, and click the button to confirm.
-        </p>
+        <h3><%= t('subscriptions.calendar.instructions_header') %></h3>
+        <p><%= t('subscriptions.calendar.instructions_paragraph1_html') %></p>
         <%= image_tag 'about/calendar_howto.png', {:style=>"width:100%"} %>
-        <p>
-          Please note, it may take a while for newly created events in <%= TeSS::Config.site['title_short'] %> to synchronise with your Google Calendar.
-        </p>
+        <p><%= t('subscriptions.calendar.instructions_paragraph2_html',
+               title: TeSS::Config.site['title_short']) %></p>
       </div>
     </div>
   </div>

--- a/app/views/subscriptions/_subscribe_to_rss_modal.html.erb
+++ b/app/views/subscriptions/_subscribe_to_rss_modal.html.erb
@@ -2,26 +2,27 @@
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+        <button type="button" class="close" data-dismiss="modal"
+                aria-label="<%= t('subscriptions.modal.close') %>">
           <span aria-hidden="true">&times;</span></button>
-        <h4 class="modal-title" id="subscribe-modal-title">Subscribe to Filter</h4>
+        <h4 class="modal-title" id="subscribe-modal-title">
+          <%= t('subscriptions.modal.subscribe_to_filter') %>
+        </h4>
       </div>
 
       <div class="modal-body">
-        <label for="rss-link">URL</label>
+        <label for="rss-link"><%= t('subscriptions.modal.url') %></label>
         <div class="input-group input-group-lg">
           <input id="rss-link" type="text" class="form-control" value="<%= url %>" readonly>
           <span class="input-group-btn">
-            <button class="btn btn-default clipboard-btn" type="button" data-clipboard-target="#rss-link" title="Click to copy">
+            <button class="btn btn-default clipboard-btn" type="button" data-clipboard-target="#rss-link"
+                    title="<%= t('subscriptions.modal.click_to_copy') %>">
               <i class="fa fa-clipboard" aria-hidden="true"></i>
             </button>
           </span>
         </div>
-        <h3>Importing into RSS reader</h3>
-        <p>
-        Import the <%= link_to url do %>feed URL<% end %> into your RSS reader to keep up to date with new events matching your filters.
-        For more information about RSS, see <%= link_to 'this page', 'https://rss.com/blog/how-do-rss-feeds-work/' %>.
-        </p>
+        <h3><%= t('subscriptions.rss.instructions_header') %></h3>
+        <p><%= t('subscriptions.rss.instructions_body_html', url: url) %></p>
       </div>
     </div>
   </div>

--- a/app/views/subscriptions/_subscription.html.erb
+++ b/app/views/subscriptions/_subscription.html.erb
@@ -2,20 +2,24 @@
   <div class="panel-body">
     <div class="row">
       <div class="col-sm-9">
-        <p><strong>Category:</strong> <%= subscription.subscribable_type.humanize.pluralize %></p>
-        <p><strong>Frequency:</strong> <%= subscription.frequency.to_s.capitalize %></p>
-        <p><strong>Last email sent:</strong> <%= subscription.last_sent_at || 'Never' %></p>
-        <p><strong>Created:</strong> <%= subscription.created_at %></p>
+        <p><strong><%= t('subscriptions.show.category') %></strong>
+           <%= subscription.subscribable_type.humanize.pluralize %></p>
+        <p><strong><%= t('subscriptions.show.frequency') %></strong>
+           <%= subscription.frequency.to_s.capitalize %></p>
+        <p><strong><%= t('subscriptions.show.last_email_sent') %></strong>
+           <%= subscription.last_sent_at || t('subscriptions.show.email_never_sent') %></p>
+        <p><strong><%= t('subscriptions.show.created_at') %></strong>
+           <%= subscription.created_at %></p>
 
         <% if subscription.query.present? %>
             <p>
-              <strong>Search term:</strong>
+              <strong><%= t('subscriptions.show.query') %></strong>
               <em><%= subscription.query %></em>
             </p>
         <% end %>
 
         <% if subscription.facets.present? %>
-            <strong>Filters:</strong>
+            <strong><%= t('subscriptions.show.filters') %></strong>
             <ul>
               <% subscription.facets.each do |facet, values| %>
                   <li>
@@ -29,11 +33,13 @@
         <% end %>
       </div>
       <div class="col-sm-3 text-right">
-        <%= link_to 'Results', subscription_results_path(subscription), class: 'btn btn-primary' %>
-        <%= link_to 'Cancel',
+        <%= link_to t('subscriptions.show.results'),
+                    subscription_results_path(subscription),
+                    class: 'btn btn-primary' %>
+        <%= link_to t('subscriptions.show.cancel'),
                     subscription,
                     method: 'delete',
-                    data: { confirm: t('.confirm', default: t("helpers.links.confirm", default: 'Are you sure?')) },
+                    data: { confirm: t('.confirm', default: t("helpers.links.confirm")) },
                     class: 'btn btn-danger' %>
       </div>
     </div>

--- a/app/views/subscriptions/index.html.erb
+++ b/app/views/subscriptions/index.html.erb
@@ -1,9 +1,9 @@
 <div class="wrapper">
   <div id="content">
-    <h2>Subscriptions</h2>
+    <h2><%= t('subscriptions.title') %></h2>
     <%= render @subscriptions %>
     <% if @subscriptions.none? %>
-        <span class="muted">You have no subscriptions.</span>
+        <span class="muted"><%= t('subscriptions.none') %></span>
     <% end %>
   </div>
 </div>

--- a/app/views/subscriptions/unsubscribe.html.erb
+++ b/app/views/subscriptions/unsubscribe.html.erb
@@ -1,1 +1,1 @@
-You have successfully unsubscribed.
+<%= t('subscriptions.unsubscribe.success') %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -907,3 +907,57 @@ en:
       parameter_change_html: changed <em>%{parameter}</em> to <strong>%{value}</strong>
       association_change_html: changed <em>%{parameter}</em> to <strong>%{name}</strong> (%{value})
       change_role_html: changed %{user} role from <strong>%{old}</strong> to <strong>%{new}</strong>
+  subscriptions:
+    title: 'Subscriptions'
+    none: 'You have no subscriptions.'
+    created: 'Subscription successfully created.'
+    cancelled: 'Subscription cancelled.'
+    problem_unsubscribing: 'There was a problem unsubscribing.'
+    invalid_code: 'Invalid code'
+    breadcrumb: 'Subscriptions'
+    modal:
+      subscribe_to_filter: 'Subscribe to Filter'
+      close: 'Close'
+      url: URL
+      click_to_copy: 'Click to copy'
+    button:
+      title: 'Subscribe'
+      via_email: 'Subscribe via email'
+      add_to_calendar: 'Add to calendar'
+      to_rss: 'Subscribe to RSS feed'
+      events_rss_feed: 'Events RSS feed'
+      email_title: 'Email Subscription'
+      submit_button: 'Subscribe'
+      frequency: 'Frequency'
+    show:
+      category: 'Category:'
+      frequency: 'Frequency:'
+      last_email_sent: 'Last email sent:'
+      email_never_sent: 'Never'
+      created_at: 'Created:'
+      query: 'Search term:'
+      filters: 'Filters:'
+      results: 'Results'
+      cancel: 'Cancel'
+    rss:
+      instructions_header: 'Importing into RSS reader'
+      instructions_body_html: >-
+        Import the <a href="%{url}">feed URL</a> into your RSS reader to keep up to
+        date with new events matching your filters. For more information about RSS, see
+        <a href="https://rss.com/blog/how-do-rss-feeds-work/"> this page</a>.
+    calendar:
+      instructions_header: 'Importing into Google Calendar'
+      instructions_paragraph1_html: >-
+        In the left-hand column of the
+        <a href="https://calendar.google.com/calendar" target="_blank" rel="noopener">Google Calendar</a>
+        main view, click the arrow to the right of "Other calendars" and click "Add by URL".
+        In the form that appears, paste in the URL from the box above, and click the button to confirm.
+      instructions_paragraph2_html: >-
+        Please note, it may take a while for newly created events in %{title} to synchronise with
+        your Google Calendar.
+    unsubscribe:
+      success: 'You have successfully unsubscribed.'
+    frequency_options:
+      daily: Daily
+      weekly: Weekly
+      monthly: Monthly


### PR DESCRIPTION
**Summary of changes**

Removing strings from view/controllers/helpers related to subscriptions and using i18n instead.

**Motivation and context**

Well, everything should go through i18n...
 
**Screenshots**

Looks the same.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
