### PR TITLE
Collapse long learning objective/pre-requisite fields when viewing a learning path

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -283,15 +283,11 @@ document.addEventListener("turbolinks:load", function(e) {
         var maxHeight = parseInt(div.dataset.origHeight) + 80;
         var limit = parseInt(div.dataset.heightLimit || "300");
 
-        if (div.clientHeight < maxHeight && this.innerHTML !== 'Show less') {
-            var newHeight = div.clientHeight + limit;
-            if (newHeight > maxHeight) {
-                div.classList.add('tess-expandable-open');
-                div.classList.remove('tess-expandable-closed');
-                newHeight = maxHeight;
-                this.innerHTML = 'Show less';
-            }
-            div.style.maxHeight = '' + newHeight + 'px';
+        if (div.classList.contains('tess-expandable-closed')) {
+            div.classList.add('tess-expandable-open');
+            div.classList.remove('tess-expandable-closed');
+            div.style.maxHeight = '' + maxHeight + 'px';
+            this.innerHTML = 'Show less';
         } else {
             div.classList.remove('tess-expandable-open');
             div.classList.add('tess-expandable-closed');

--- a/app/helpers/materials_helper.rb
+++ b/app/helpers/materials_helper.rb
@@ -101,7 +101,7 @@ where each topic has one competency level for all its materials. \n\n\
     end
   end
 
-  def display_attribute(resource, attribute, show_label: true, title: nil, markdown: false, list: false)
+  def display_attribute(resource, attribute, show_label: true, title: nil, markdown: false, list: false, expandable: false)
     return if [
       TeSS::Config.feature['disabled'].include?(attribute.to_s),
       (TeSS::Config.feature['materials_disabled'].include?(attribute.to_s) && resource.is_a?(Material)),
@@ -120,6 +120,9 @@ where each topic has one competency level for all its materials. \n\n\
           string << "<li>#{block_given? ? yield(v) : v}</li>"
         end
         string << '</ul>'
+      elsif expandable
+        height_limit = expandable.is_a?(Numeric) ? expandable : nil
+        string << "<div class=\"tess-expandable\"#{" data-height-limit=\"#{height_limit}\"" if height_limit}>" + value.to_s + '</div>'
       else
         string << value.to_s
       end

--- a/app/views/common/_extra_metadata.html.erb
+++ b/app/views/common/_extra_metadata.html.erb
@@ -68,8 +68,8 @@
 <% if resource.is_a?(LearningPath) %>
   <%= display_attribute(resource, :status) { |value| material_status_title_for_label(value) } %>
   <%= display_attribute(resource, :target_audience) { |values| values.map { |x| target_audience_title_for_label(x) }.join(', ') } %>
-  <%= display_attribute(resource, :prerequisites, markdown: true) %>
-  <%= display_attribute(resource, :learning_objectives, markdown: true) %>
+  <%= display_attribute(resource, :prerequisites, markdown: true, expandable: 150) %>
+  <%= display_attribute(resource, :learning_objectives, markdown: true, expandable: 150) %>
 <% end %>
 
 <% if resource.respond_to?(:operations) -%>

--- a/app/views/layouts/_user_menu.html.erb
+++ b/app/views/layouts/_user_menu.html.erb
@@ -6,13 +6,13 @@
   <ul class="dropdown-menu dropdown-menu-right">
     <li class="dropdown-item">
       <%= link_to user_path(current_user),  title: current_user.username do %>
-        <i class="fa fa-user-circle"></i><%= t('menu.user.my_profile')%>
+        <i class="fa fa-user-circle"></i> <%= t('menu.user.my_profile')%>
       <% end %>
     </li>
 
     <li class="dropdown-item">
       <%= link_to stars_path, title: t('menu.user.view_stars') do %>
-        <i class="fa fa-star"></i><%= t('menu.user.my_stars') %>
+        <i class="fa fa-star"></i> <%= t('menu.user.my_stars') %>
       <% end %>
     </li>
 
@@ -23,13 +23,13 @@
 
       <li class="dropdown-item">
         <%= link_to users_path, title: t('menu.user.view_users') do %>
-          <i class="fa fa-users"></i><%= t('menu.user.view_users') %>
+          <i class="fa fa-users"></i> <%= t('menu.user.view_users') %>
         <% end %>
       </li>
       <% if TeSS::Config.feature['sources'] %>
         <li class="dropdown-item">
           <%= link_to sources_path, title: t('menu.user.view_ingestion_sources') do %>
-            <i class="fa fa-cloud-download"></i><%= t('menu.user.view_sources') %>
+            <i class="fa fa-cloud-download"></i> <%= t('menu.user.view_sources') %>
           <% end %>
         </li>
       <% end %>
@@ -38,19 +38,19 @@
           <%= link_to curate_topic_suggestions_path,
                       title: t('menu.user.assign_scientific_topics',
                                title: TeSS::Config.site['title_short']) do %>
-            <i class="fa fa-briefcase"></i><%= t('menu.user.curate_topics') %>
+            <i class="fa fa-briefcase"></i> <%= t('menu.user.curate_topics') %>
           <% end %>
         </li>
       <% end %>
       <li class="dropdown-item">
         <%= link_to curate_users_path(with_content: true) do %>
-          <i class="fa fa-user-times"></i><%= t('menu.user.curate_users') %>
+          <i class="fa fa-user-times"></i> <%= t('menu.user.curate_users') %>
         <% end %>
       </li>
       <li class="dropdown-item">
         <% if current_user.is_admin? %>
           <%= link_to rails_admin_path, title: t('menu.user.view_admin_console') do %>
-            <i class="fa fa-cog"></i><%= t('menu.user.admin_console') %>
+            <i class="fa fa-cog"></i> <%= t('menu.user.admin_console') %>
           <% end %>
         <% end %>
       </li>

--- a/app/views/learning_paths/show.html.erb
+++ b/app/views/learning_paths/show.html.erb
@@ -45,7 +45,9 @@
 
         <!-- Field: long description -->
         <div class="description">
-          <%= render_markdown @learning_path.description %>
+          <div class="tess-expandable">
+            <%= render_markdown @learning_path.description %>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
**Summary of changes**

- Add `expandable` option to `display_attribute`, which limits the max vertical height of the attribute value, adding a "See more/less" link to expand/collapse.
- Makes expandable elements expand to max height when "See more" is clicked, instead of gradually showing more content.
- Add some spacing between icons and text in user menu.

**Motivation and context**

#1096
 
**Screenshots**

![image](https://github.com/user-attachments/assets/082c66c0-631e-4fb3-9d12-a2c2fda911dd)

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
