### PR TITLE
Log activity when resources are scraped

### DIFF
--- a/app/views/public_activity/common/_create.html.erb
+++ b/app/views/public_activity/common/_create.html.erb
@@ -2,3 +2,11 @@
 <%= activity_owner(activity) %>
 <%= t('activity.actions.create') %> <%= activity_resource(activity) %>
 <%= t('activity.timestamp', time: activity.created_at) -%>.
+<% source = activity.parameters[:source] %>
+<% if source && (current_user.is_admin? || current_user.is_curator?) %>
+  <div class="sub-activity">
+    <%= source[:id] ? link_to('Source', source_path(source[:id])) : '[sources.yml source]' %> -
+    <%= source[:method] %> @
+    <%= link_to(source[:url], source[:url], target: :_blank) %>
+  </div>
+<% end %>

--- a/lib/ingestors/ingestor.rb
+++ b/lib/ingestors/ingestor.rb
@@ -159,7 +159,7 @@ module Ingestors
               method: source.method
             }
           end
-          resource.create_activity(:create, owner: user, parameters: activity_params)
+          resource.create_activity(update ? :update : :create, owner: user, parameters: activity_params)
           @stats[key][update ? :updated : :added] += 1
         else
           @stats[key][:rejected] += 1

--- a/lib/ingestors/ingestor.rb
+++ b/lib/ingestors/ingestor.rb
@@ -151,6 +151,15 @@ module Ingestors
         resource = set_resource_defaults(resource)
         if resource.valid?
           resource.save!
+          activity_params = {}
+          if source
+            activity_params[:source] = {
+              id: source.id,
+              url: source.url,
+              method: source.method
+            }
+          end
+          resource.create_activity(:create, owner: user, parameters: activity_params)
           @stats[key][update ? :updated : :added] += 1
         else
           @stats[key][:rejected] += 1

--- a/test/unit/ingestors/scraper_test.rb
+++ b/test/unit/ingestors/scraper_test.rb
@@ -277,7 +277,6 @@ class ScraperTest < ActiveSupport::TestCase
 
     refute provider.events.where(url: 'https://uppsala.instructure.com/courses/75565').exists?
     assert provider.events.where(url: 'https://uppsala.instructure.com/courses/73110').exists?
-    acts = PublicActivity::Activity.all.to_a
     assert_difference('provider.events.count', 22) do
       assert_difference('PublicActivity::Activity.where(key: "event.create").count', 22) do
         assert_difference('PublicActivity::Activity.where(key: "event.update").count', 1) do

--- a/test/unit/ingestors/scraper_test.rb
+++ b/test/unit/ingestors/scraper_test.rb
@@ -267,34 +267,54 @@ class ScraperTest < ActiveSupport::TestCase
     source = Source.create!(url: 'https://somewhere.com/stuff', method: 'bioschemas',
                             enabled: true, approval_status: 'approved',
                             content_provider: provider, user: users(:admin))
+
+    existing_event = provider.events.create!(url: 'https://uppsala.instructure.com/courses/73110', title: 'Existing', user: users(:regular_user))
+    existing_activities = existing_event.activities.to_a
+
     file = Rails.root.join('test', 'fixtures', 'files', 'ingestion', 'nbis-course-instances.json')
     WebMock.stub_request(:get, source.url).to_return(status: 200, headers: {}, body: file.read)
     scraper = Scraper.new
 
     refute provider.events.where(url: 'https://uppsala.instructure.com/courses/75565').exists?
-    assert_difference('provider.events.count', 23) do
-      assert_difference('PublicActivity::Activity.count', 23) do
-        scraper.scrape(source)
+    assert provider.events.where(url: 'https://uppsala.instructure.com/courses/73110').exists?
+    acts = PublicActivity::Activity.all.to_a
+    assert_difference('provider.events.count', 22) do
+      assert_difference('PublicActivity::Activity.where(key: "event.create").count', 22) do
+        assert_difference('PublicActivity::Activity.where(key: "event.update").count', 1) do
+          scraper.scrape(source)
+        end
       end
     end
     assert provider.events.where(url: 'https://uppsala.instructure.com/courses/75565').exists?
     source.reload
     assert_equal 23, source.records_read
     assert_equal 23, source.records_written
-    assert_equal 23, source.resources_added
-    assert_equal 0, source.resources_updated
+    assert_equal 22, source.resources_added
+    assert_equal 1, source.resources_updated
     assert_equal 0, source.resources_rejected
     assert source.finished_at > 1.day.ago
     assert_includes source.log, 'Bioschemas summary'
     assert_includes source.log, '- CourseInstances: 23'
 
-    activity = PublicActivity::Activity.last
-    assert_equal 'event.create', activity.key
-    assert_equal 'scraper', activity.owner.username
-    parameters = activity.parameters[:source]
+    create_activity = PublicActivity::Activity.last
+    assert_equal 'event.create', create_activity.key
+    assert_equal 'scraper', create_activity.owner.username
+    parameters = create_activity.parameters[:source]
     assert_equal source.id, parameters[:id]
     assert_equal 'bioschemas', parameters[:method]
     assert_equal 'https://somewhere.com/stuff', parameters[:url]
+
+    new_activities = existing_event.reload.activities.to_a - existing_activities
+    update_activities = new_activities.select { |a| a.key == 'event.update' }
+    assert_equal 1, update_activities.count
+    update_activity = update_activities.first
+    assert_equal 'scraper', update_activity.owner.username
+    parameters = update_activity.parameters[:source]
+    assert_equal source.id, parameters[:id]
+    assert_equal 'bioschemas', parameters[:method]
+    assert_equal 'https://somewhere.com/stuff', parameters[:url]
+    parameter_update_activities = new_activities.select { |a| a.key == 'event.update_parameter' }
+    assert_equal 7, parameter_update_activities.count
   end
 
   def set_up_event_check


### PR DESCRIPTION
**Summary of changes**

- Ensures a `PublicActivity::Activity` is created when a resource is created/update via the scraper, to match the behaviour of the UI
- Displays some info on the `Source` where the resource was scraped from under the activity in the log (only visible to administrators and curators)

**Motivation and context**

The "Activity Log" for scraped resources was confusing as it only listed parameter changes. Additionally, if multiple sources updated the same resource, it was difficult to track down which.
 
**Screenshots**

![image](https://github.com/user-attachments/assets/72a778cc-3157-412e-b6a7-3c8a9d9de639)

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
