### PR TITLE
Protect locked fields from multiple methods of assignment

### DIFF
--- a/app/controllers/concerns/field_lock_enforcement.rb
+++ b/app/controllers/concerns/field_lock_enforcement.rb
@@ -12,9 +12,6 @@ module FieldLockEnforcement
     resource = instance_variable_get("@#{resource_type}")
 
     params[resource_type].delete(:locked_fields)
-
-    resource.locked_fields.each do |field|
-      params[resource_type].delete(field)
-    end
+    FieldLock.strip_locked_fields(params[resource_type], resource.locked_fields)
   end
 end

--- a/app/models/field_lock.rb
+++ b/app/models/field_lock.rb
@@ -3,4 +3,16 @@ class FieldLock < ApplicationRecord
   belongs_to :resource, polymorphic: true
   validates :field, presence: true
 
+  ALIASES = {
+    node_ids: [:node_names]
+  }.freeze
+
+  def self.strip_locked_fields(params, locked_fields)
+    locked_fields.each do |field|
+      params.delete(field)
+      ALIASES[field]&.each do |field_alias|
+        params.delete(field_alias)
+      end
+    end
+  end
 end

--- a/lib/ingestors/ingestor.rb
+++ b/lib/ingestors/ingestor.rb
@@ -172,10 +172,10 @@ module Ingestors
 
     def update_resource(existing_resource, fields)
       # overwrite unlocked attributes
-      locked_fields = existing_resource.locked_fields
+      FieldLock.strip_locked_fields(fields, existing_resource.locked_fields)
 
       fields.except(:content_provider_id, :user_id).each do |attr, value|
-        existing_resource.send("#{attr}=", value) unless locked_fields.include?(attr)
+        existing_resource.send("#{attr}=", value)
       end
 
       existing_resource

--- a/test/models/field_lock_test.rb
+++ b/test/models/field_lock_test.rb
@@ -29,4 +29,15 @@ class FieldLockTest < ActiveSupport::TestCase
     end
   end
 
+  test 'strips aliased fields' do
+    event = events(:one)
+
+    event.locked_fields = [:title, :node_ids]
+
+    params = { event: { title: 'Something', description: 'Something else', node_names: ['One', 'Two'] } }.with_indifferent_access
+    FieldLock.strip_locked_fields(params[:event], event.locked_fields)
+    assert_equal({ description: 'Something else' }.with_indifferent_access, params[:event])
+
+  end
+
 end


### PR DESCRIPTION
**Summary of changes**

- Allows field lock aliases to be defined for fields with multiple methods of assignment (e.g. nodes can be set by `node_names=` or `node_ids=`)

**Motivation and context**

A user was manually assigning nodes to training materials, but they were being cleared the next time the materials were scraped, even though the `node_ids` field was locked.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
