### PR TITLE
Handle deleted collection items

### DIFF
--- a/app/assets/javascripts/templates/autocompleter/collection_item.hbs
+++ b/app/assets/javascripts/templates/autocompleter/collection_item.hbs
@@ -9,7 +9,11 @@
         <input type="hidden" name="{{ prefix }}[][id]" value="{{ item.id }}" />
         <input type="hidden" name="{{ prefix }}[][resource_id]" value="{{ item.resource_id }}" />
         <input type="hidden" name="{{ prefix }}[][resource_type]" value="{{ item.resource_type }}" />
+        {{#if item.url}}
         <a href="{{ item.url }}" target="_blank">{{ item.title }}</a>
+        {{ else }}
+        <span class="muted">{{ item.title }}</span>
+        {{/if}}
         <input type="text" class="form-control input-sm" name="{{ prefix }}[][comment]" placeholder="Enter a comment" value="{{ item.comment }}">
     </div>
 

--- a/app/assets/stylesheets/masonry.scss
+++ b/app/assets/stylesheets/masonry.scss
@@ -81,6 +81,23 @@
   opacity: 1;
 }
 
+.deleted-item-overlay {
+  text-decoration: none;
+  color: $gray-darker;
+  @include floating-card;
+  border-radius: 8px;
+  padding: $item-padding-base;
+  display: block;
+  transition: $transition-time;
+
+  h4 {
+    margin-top: 0;
+    margin-bottom: 0;
+    color: $text-muted;
+    font-style: italic;
+  }
+}
+
 .link-overlay {
   text-decoration: none;
   color: $gray-darker;

--- a/app/models/collection_item.rb
+++ b/app/models/collection_item.rb
@@ -14,10 +14,12 @@ class CollectionItem < ApplicationRecord
     self.collection.create_activity(:add_item, owner: User.current_user,
                                     parameters: { resource_id: self.resource_id,
                                                   resource_type: self.resource_type,
-                                                  resource_title: self.resource.title })
-    self.resource.create_activity(:add_to_collection, owner: User.current_user,
-                                  parameters: { collection_id: self.collection_id,
-                                                collection_title: self.collection.title })
+                                                  resource_title: self.resource&.title })
+    if self.resource
+      self.resource.create_activity(:add_to_collection, owner: User.current_user,
+                                    parameters: { collection_id: self.collection_id,
+                                                  collection_title: self.collection.title })
+    end
   end
 
   def reindex_resource

--- a/app/models/learning_path_topic_item.rb
+++ b/app/models/learning_path_topic_item.rb
@@ -13,10 +13,12 @@ class LearningPathTopicItem < ApplicationRecord
     self.topic.create_activity(:add_item, owner: User.current_user,
                                parameters: { resource_id: self.resource_id,
                                              resource_type: self.resource_type,
-                                             resource_title: self.resource.title })
-    self.resource.create_activity(:add_to_topic, owner: User.current_user,
-                                  parameters: { topic_id: self.topic_id,
-                                                topic_title: self.topic.title })
+                                             resource_title: self.resource&.title })
+    if self.resource
+      self.resource.create_activity(:add_to_topic, owner: User.current_user,
+                                    parameters: { topic_id: self.topic_id,
+                                                  topic_title: self.topic.title })
+    end
   end
 
   def previous_item

--- a/app/views/collection_items/_collection_item.html.erb
+++ b/app/views/collection_items/_collection_item.html.erb
@@ -1,2 +1,6 @@
 <% resource = collection_item.resource %>
-<%= render partial: resource, locals: { collection_item: collection_item } %>
+<% if resource %>
+  <%= render partial: resource, locals: { collection_item: collection_item } %>
+<% else %>
+  <%= render partial: 'common/deleted_resource', locals: { collection_item: collection_item } %>
+<% end %>

--- a/app/views/collections/_collection_items_form.erb
+++ b/app/views/collections/_collection_items_form.erb
@@ -15,7 +15,7 @@
   json = items.map do |item|
     { item: { id: item.id, order: item.order, comment: item.comment,
               resource_id: item.resource_id, resource_type: item.resource_type,
-              title: item.resource.title, url: polymorphic_path(item.resource) },
+              title: item.resource&.title || t('deleted_resource'), url: item.resource ? polymorphic_path(item.resource) : nil },
       prefix: form_field_name }
   end.to_json
 

--- a/app/views/common/_deleted_resource.html.erb
+++ b/app/views/common/_deleted_resource.html.erb
@@ -1,0 +1,18 @@
+<% learning_path_topic_item ||= nil %>
+<% collection_item ||= learning_path_topic_item %>
+<%
+  unless defined? show_order
+    show_order = true
+  end
+%>
+<li class="masonry-brick media-item long">
+  <div class="deleted-item-overlay">
+    <%= item_order_badge(collection_item) if show_order && collection_item %>
+
+    <div class="masonry-brick-heading muted">
+      <h4><%= t('deleted_resource') %></h4>
+    </div>
+
+    <%= item_comment(collection_item) if collection_item %>
+  </div>
+</li>

--- a/app/views/learning_path_topic_items/_learning_path_topic_item.html.erb
+++ b/app/views/learning_path_topic_items/_learning_path_topic_item.html.erb
@@ -1,2 +1,6 @@
 <% resource = learning_path_topic_item.resource %>
-<%= render partial: resource, locals: local_assigns %>
+<% if resource %>
+  <%= render partial: resource, locals: local_assigns %>
+<% else %>
+  <%= render partial: 'common/deleted_resource', locals: local_assigns %>
+<% end %>

--- a/app/views/public_activity/common/_add_item.html.erb
+++ b/app/views/public_activity/common/_add_item.html.erb
@@ -1,7 +1,7 @@
 <% type = activity.parameters[:resource_type].constantize %>
 <i class="fa fa-pencil-square-o"></i>
 <%= activity_owner(activity) %>
-<%= t('activity.actions.add') %> <%= type.model_name.human.downcase %> <%= link_to activity.parameters[:resource_title],
+<%= t('activity.actions.add') %> <%= type.model_name.human.downcase %> <%= link_to activity.parameters[:resource_title] || t('deleted_resource'),
                                                                                    polymorphic_path(type.model_name.singular.to_sym,
                                                                                                     id: activity.parameters[:resource_id]) %>
 <%= t('activity.target_html', resource: activity_resource(activity)) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -963,3 +963,4 @@ en:
       daily: Daily
       weekly: Weekly
       monthly: Monthly
+  deleted_resource: Deleted resource

--- a/test/controllers/collections_controller_test.rb
+++ b/test/controllers/collections_controller_test.rb
@@ -734,4 +734,20 @@ class CollectionsControllerTest < ActionController::TestCase
     get :show, params: { id: collection }
     assert_response :forbidden
   end
+
+  test 'should show collection with deleted resource' do
+    m1 = materials(:biojs)
+    m2 = materials(:interpro)
+    ci1 = @collection.items.create!(resource: materials(:biojs), order: 2, comment: 'hello')
+    ci2 = @collection.items.create!(resource: materials(:interpro), order: 1, comment: 'hello!!')
+    assert_no_difference('CollectionItem.count') do
+      m1.destroy!
+    end
+
+    get :show, params: { id: @collection }
+    assert_response :success
+    assert_select '.deleted-item-overlay', count: 1 do
+      assert_select 'h4', text: 'Deleted resource'
+    end
+  end
 end

--- a/test/controllers/collections_controller_test.rb
+++ b/test/controllers/collections_controller_test.rb
@@ -750,4 +750,42 @@ class CollectionsControllerTest < ActionController::TestCase
       assert_select 'h4', text: 'Deleted resource'
     end
   end
+
+  test 'can edit collection with deleted resource' do
+    sign_in @collection.user
+
+    m1 = materials(:biojs)
+    m2 = materials(:interpro)
+    ci1 = @collection.items.create!(resource: materials(:biojs), order: 2, comment: 'hello')
+    ci2 = @collection.items.create!(resource: materials(:interpro), order: 1, comment: 'hello!!')
+    assert_no_difference('CollectionItem.count') do
+      m1.destroy!
+    end
+
+    get :edit, params: { id: @collection }
+    assert_response :success
+  end
+
+  test 'can update collection with deleted resource' do
+    sign_in @collection.user
+
+    m1 = materials(:biojs)
+    m2 = materials(:interpro)
+    ci1 = @collection.items.create!(resource: materials(:biojs), order: 2, comment: 'hello')
+    ci2 = @collection.items.create!(resource: materials(:interpro), order: 1, comment: 'hello!!')
+    assert_no_difference('CollectionItem.count') do
+      m1.destroy!
+    end
+
+    params = { id: ci1.id, resource_type: ci1.resource_type, resource_id: ci1.resource_id }
+
+    patch :update, params: { id: @collection.id,
+                             collection: {
+                               items_attributes: { '1': params.merge(comment: 'Some comment') }
+                             }
+    }
+
+    assert_redirected_to collection_path(assigns(:collection))
+    assert_equal 'Some comment', ci1.reload.comment
+  end
 end

--- a/test/controllers/learning_path_topics_controller_test.rb
+++ b/test/controllers/learning_path_topics_controller_test.rb
@@ -554,4 +554,16 @@ class LearningPathTopicsControllerTest < ActionController::TestCase
     response_events = body.dig('data', 'relationships', 'events', 'data')
     assert_equal [events[1].id, events[0].id], response_events.map { |e| e['id'].to_i }
   end
+
+  test 'should show learning_path_topic with deleted resource' do
+    topic_item = @learning_path_topic.items.first
+    assert_no_difference('LearningPathTopicItem.count') do
+      topic_item.resource.destroy!
+    end
+
+    get :show, params: { id: @learning_path_topic }
+    assert_select '.deleted-item-overlay', count: 1 do
+      assert_select 'h4', text: 'Deleted resource'
+    end
+  end
 end

--- a/test/controllers/learning_path_topics_controller_test.rb
+++ b/test/controllers/learning_path_topics_controller_test.rb
@@ -566,4 +566,36 @@ class LearningPathTopicsControllerTest < ActionController::TestCase
       assert_select 'h4', text: 'Deleted resource'
     end
   end
+
+  test 'can edit learning_path_topic with deleted resource' do
+    sign_in @learning_path_topic.user
+
+    topic_item = @learning_path_topic.items.first
+    assert_no_difference('LearningPathTopicItem.count') do
+      topic_item.resource.destroy!
+    end
+
+    get :edit, params: { id: @learning_path_topic }
+    assert_response :success
+  end
+
+  test 'can update learning_path_topic with deleted resource' do
+    sign_in @learning_path_topic.user
+
+    topic_item = @learning_path_topic.items.first
+    params = { id: topic_item.id, resource_type: topic_item.resource_type, resource_id: topic_item.resource_id }
+    assert_no_difference('LearningPathTopicItem.count') do
+      topic_item.resource.destroy!
+    end
+
+    get :edit, params: { id: @learning_path_topic }
+    patch :update, params: { id: @learning_path_topic.id,
+                             learning_path_topic: {
+                               items_attributes: { '1': params.merge(comment: 'Some comment') }
+                             }
+    }
+
+    assert_redirected_to learning_path_topic_path(assigns(:learning_path_topic))
+    assert_equal 'Some comment', topic_item.reload.comment
+  end
 end

--- a/test/controllers/learning_paths_controller_test.rb
+++ b/test/controllers/learning_paths_controller_test.rb
@@ -518,4 +518,19 @@ class LearningPathsControllerTest < ActionController::TestCase
     assert_select '.link-overlay[href=?]',
                   material_path(topic_item.resource, lp: [topic_link, topic_item].map(&:id).join(':'))
   end
+
+  test 'should show learning path with deleted resource' do
+    topic_link = @learning_path.topic_links.first
+    topic_item = topic_link.topic.items.first
+    assert_no_difference('LearningPathTopicItem.count') do
+      topic_item.resource.destroy!
+    end
+
+    get :show, params: { id: @learning_path }
+    assert_response :success
+    assert_response :success
+    assert_select '.deleted-item-overlay', count: 1 do
+      assert_select 'h4', text: 'Deleted resource'
+    end
+  end
 end


### PR DESCRIPTION
**Summary of changes**

- Displays a "tombstone" where an item in a collection or learning path topic has been deleted.

**Motivation and context**

#1108

Opted not to delete the `CollectionItem`/`LearningPathTopicItem` because there could be useful context in the comment.

**Screenshots**

![image](https://github.com/user-attachments/assets/8c959bad-f4e5-422d-b35e-09b64230c99d)

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
