### PR TITLE
Visibility feature tweaks

### DIFF
--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -3,7 +3,9 @@
   <%= render partial: 'common/error_summary', locals: { resource: @event } %>
 
   <!-- Field: Disabled -->
-  <%= f.input :visible, label: 'Show this event?', input_html: { title: t('events.hints.visible') } %>
+  <% unless TeSS::Config.feature['disabled'].include?('visibility') %>
+    <%= f.input :visible, hint: t('events.hints.visible') %>
+  <% end %>
 
   <!-- Field: presence -->
   <div class="form-group">

--- a/app/views/materials/_form.html.erb
+++ b/app/views/materials/_form.html.erb
@@ -3,7 +3,9 @@
   <%= render partial: 'common/error_summary', locals: { resource: @material } %>
 
   <!-- Field: Disabled -->
-  <%= f.input :visible, label: 'Show this material?', input_html: { title: t('materials.hints.visible') } %>
+  <% unless TeSS::Config.feature['disabled'].include?('visibility') %>
+    <%= f.input :visible, hint: t('materials.hints.visible') %>
+  <% end %>
 
   <%# Necessary to allow removal of all field locks %>
   <%= hidden_field_tag 'material[locked_fields][]', '' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -571,7 +571,7 @@ en:
       cost_value: 'Input the cost of the training event.'
       cost_currency: 'Select the currency associated with the cost.'
       description: 'Provide a textual description of the training event, for additional context.'
-      visible: 'Whether or not this event should be shown on the events page'
+      visible: 'Whether this event should be shown or hidden from the events page.'
       duration: 'In hours and minutes (HH:MM), how long will your training event run?'
       eligibility: 'Who can attend the training event?'
       end: 'When does the event end?'
@@ -636,7 +636,7 @@ en:
       resource_type: 'Select the type of resource that best matches the training material. '
       url: 'Preferred URL to direct people to your training material landing page.'
       version: 'Indicate the current version of the training material.'
-      visible: 'Whether or not this material should be shown on the materials page'
+      visible: 'Whether this material should be shown or hidden from the materials page.'
   learning_paths:
     hints:
       authors: >
@@ -964,3 +964,9 @@ en:
       weekly: Weekly
       monthly: Monthly
   deleted_resource: Deleted resource
+  simple_form:
+    labels:
+      event:
+        visible: Show this event?
+      material:
+        visible: Show this material?


### PR DESCRIPTION
**Summary of changes**

- Allow event/material visibility checkbox to be disabled
- Display the hint at all times, without requiring hover
- I18n

**Motivation and context**

A user wasn't clear about what the checkbox does, and it is the first thing you see on the new event form
 
**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
