### PR TITLE
Profile form fixes

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -10,7 +10,8 @@ module SearchHelper
   end
 
   def facet_title(name, value, html_options = {})
-    return render_language_name(value) if name == 'language'
+    lang = render_language_name(value) if name == 'language'
+    return lang unless lang.blank?
 
     html_options.delete(:title) || truncate(value.to_s, length: 50)
   end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -10,7 +10,7 @@ module SearchHelper
   end
 
   def facet_title(name, value, html_options = {})
-    lang = render_language_name(value) if name == 'language'
+    lang = render_language_name(value) if name.to_s == 'language'
     return lang unless lang.blank?
 
     html_options.delete(:title) || truncate(value.to_s, length: 50)

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -86,7 +86,12 @@ module Searchable
           end
         end
 
-        if attribute_method?(:public) && !user&.is_admin? # Find a better way of checking this
+        if name == 'Trainer' || name == 'Profile'
+          # `public` means "Show in trainer registry" for Trainers/Profiles
+          any_of do
+            with(:public, true)
+          end
+        elsif attribute_method?(:public) && !user&.is_admin? # Find a better way of checking this
           any_of do
             with(:public, true)
             with(:user_id, user.id) if user

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -94,7 +94,7 @@ class Profile < ApplicationRecord
   end
 
   def reindex
-    if Rails.env.production?
+    if TeSS::Config.solr_enabled
       Trainer.reindex
     end
   end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -9,47 +9,13 @@ class Profile < ApplicationRecord
   validates :website, url: true, http_url: true, allow_blank: true
   validates :orcid, orcid: true, allow_blank: true
   after_validation :check_public
+  after_commit :reindex_trainer
   clean_array_fields(:expertise_academic, :expertise_technical, :fields,
                      :interest, :activity, :language, :social_media)
   update_suggestions(:expertise_technical, :interest)
 
   extend FriendlyId
   friendly_id :full_name, use: :slugged
-
-  after_update_commit :reindex
-  after_destroy_commit :reindex
-
-  if TeSS::Config.solr_enabled
-    # :nocov:
-    searchable do
-      # full text search fields
-      text :firstname
-      text :surname
-      text :description
-      # sort title
-      string :sort_title do
-        full_name.downcase
-      end
-      # other fields
-      integer :user_id
-      string :full_name
-      string :location
-      string :orcid
-      string :experience do
-        TrainerExperienceDictionary.instance.lookup_value(self.experience, 'title')
-      end
-      string :expertise_academic, multiple: true
-      string :expertise_technical, multiple: true
-      string :fields, :multiple => true
-      string :interest, multiple: true
-      string :activity, multiple: true
-      string :language, multiple: true
-      string :social_media, multiple: true
-      time :updated_at
-      boolean :public
-    end
-    # :nocov:
-  end
 
   def self.facet_fields
     field_list = %w( full_name )
@@ -93,14 +59,14 @@ class Profile < ApplicationRecord
     public ? self.type = 'Trainer' : self.type = 'Profile'
   end
 
-  def reindex
-    if TeSS::Config.solr_enabled
-      Trainer.reindex
-    end
-  end
-
   def should_generate_new_friendly_id?
     firstname_changed? or surname_changed?
   end
 
+  # This is needed if the `public` status of the profile changes when it is already instantiated - it won't be cast
+  # to a Trainer object and indexed by solr (only Trainer class is `searchable`).
+  def reindex_trainer
+    return unless TeSS::Config.solr_enabled
+    becomes(Trainer).solr_index
+  end
 end

--- a/app/models/trainer.rb
+++ b/app/models/trainer.rb
@@ -2,10 +2,6 @@ require 'i18n_data'
 
 # define model for Trainer as subset of Profile
 class Trainer < Profile
-
-  after_update_commit :reindex
-  after_destroy_commit :reindex
-
   extend FriendlyId
   friendly_id :full_name, use: :slugged
 

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -57,9 +57,8 @@
                       label: 'Training Experience', prompt: 'Select a level of experience...',
                       input_html: { title: t('profile.hints.experience') } %>
 
-          <%= f.input :language, options: language_options_for_select,
-                         label: 'Languages Spoken', model_name: 'user[profile_attributes]', as: :select,
-             input_html: { class: 'js-select2' },
+          <%= f.dropdown :language, options: language_options_for_select,
+                         label: t('simple_form.labels.profile.language'), model_name: 'user[profile_attributes]', as: :select,
                          errors: @user.profile.errors[:language], title: t('profile.hints.language') %>
 
           <%= f.multi_input :expertise_academic, label: 'Academic expertise',

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -37,7 +37,7 @@
         <% end %>
 
         <% if @user.is_admin?%>
-          <%= f.input :check_broken_scrapers, label: 'Receive emails with scrapers that have not found anything last period.' %>
+          <%= user_f.input :check_broken_scrapers %>
         <% end %>
 
         <% if TeSS::Config.feature['trainers'] %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -972,3 +972,5 @@ en:
         visible: Show this material?
       user:
         check_broken_scrapers: Receive emails with scrapers that have not found anything last period.
+      profile:
+        language: Languages Spoken

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -970,3 +970,5 @@ en:
         visible: Show this event?
       material:
         visible: Show this material?
+      user:
+        check_broken_scrapers: Receive emails with scrapers that have not found anything last period.

--- a/test/controllers/trainers_controller_test.rb
+++ b/test/controllers/trainers_controller_test.rb
@@ -8,7 +8,8 @@ class TrainersControllerTest < ActionController::TestCase
     assert_response :success
     trainers = assigns(:trainers)
     assert_not_nil trainers
-    assert_equal 1, trainers.size
+    assert_equal 2, trainers.size
+    assert_includes trainers, users(:trainer_user).profile
   end
 
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -469,7 +469,7 @@ class UsersControllerTest < ActionController::TestCase
     refute assigns(:users).include?(users(:basic_user))
   end
 
-  test 'should get edit for trainers feature enabled' do
+  test "should get edit for trainers feature enabled" do
     user = users(:trainer_user)
     sign_in(user)
     get :edit, params: { id: user }

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -118,9 +118,19 @@ class UsersControllerTest < ActionController::TestCase
   end
 
   test "should update profile" do
-    sign_in users(:regular_user)
-    patch :update, params: { id: @user, user: { profile_attributes: { email: 'hot@mail.com' } } }
+    sign_in @user
+    profile_id = @user.profile.id
+    patch :update, params: { id: @user, user: { profile_attributes: { id: profile_id, email: 'hot@mail.com' } } }
     assert_redirected_to user_path(assigns(:user))
+    assert_equal profile_id, assigns(:user).profile.id
+  end
+
+  test "should not update profile ID" do
+    sign_in @user
+    another_profile_id = users(:another_regular_user).profile.id
+    patch :update, params: { id: @user, user: { profile_attributes: { id: another_profile_id, email: 'hot@mail.com' } } }
+    assert_response :forbidden
+    assert_not_equal another_profile_id, @user.reload.profile.id
   end
 
   test "should reset token" do

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -458,4 +458,16 @@ class UsersControllerTest < ActionController::TestCase
     assert_response :success
     refute assigns(:users).include?(users(:basic_user))
   end
+
+  test 'should get edit for trainers feature enabled' do
+    user = users(:trainer_user)
+    sign_in(user)
+    get :edit, params: { id: user }
+    assert_response :success
+
+    user = users(:admin_trainer)
+    sign_in(user)
+    get :edit, params: { id: user }
+    assert_response :success
+  end
 end

--- a/test/fixtures/profiles.yml
+++ b/test/fixtures/profiles.yml
@@ -83,3 +83,10 @@ trainer_two_profile:
   expertise_technical: ['java', 'python', 'ruby']
   public: false
   type: Profile
+
+admin_trainer_profile:
+  user: admin_trainer
+  firstname: Adminson
+  surname: Trainer
+  public: true
+  type: Trainer

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -158,3 +158,11 @@ learning_path_curator:
   encrypted_password: 'learning_paths_curator_encrypted_password'
   confirmed_at: <%= Time.zone.now %>
   role: learning_path_curator
+
+admin_trainer:
+  username: 'Trainer Admin'
+  email: 'adam-trainer@notarealdomain.org'
+  encrypted_password: 'admin_encrypted_password'
+  confirmed_at: <%= Time.zone.now %>
+  role: admin
+  check_broken_scrapers: true

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -220,6 +220,8 @@ class ActiveSupport::TestCase
     WebMock.stub_request(:get, 'https://bio.tools/api/tool?q=Material%20with%20suggestions')
            .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent' => 'Ruby' })
            .to_return(status: 200, body: '', headers: {})
+
+    WebMock.stub_request(:any, 'http://example.com/').to_return(status: 200)
   end
 
   def mock_orcids


### PR DESCRIPTION
**Summary of changes**

- Prevents a new profile record being created each time the user updates their profile.
- Fixes trainer language filter options being blank
- Fixes trainer filters showing even when no trainers in the list
- Fixes 500 when trying to edit profile as an admin
- Refactors trainer/profile reindexing behaviour (no longer requires full reindex when a single record changes)

**Motivation and context**

User noticed trainer language select on profile edit page was showing Yes/No options instead of languages, ran into other issues whilst debugging.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
