### PR TITLE
Option: search_box

### DIFF
--- a/app/views/static/home/_search_box.html.erb
+++ b/app/views/static/home/_search_box.html.erb
@@ -1,0 +1,12 @@
+<%# Big search box %>
+<div class="searchbox">
+  <%= form_tag search_path, method: :get, role: 'search' do %>
+    <div class="searchbox-wrapper">
+      <input type="text" class="searchbox-field" name="q"
+              placeholder= "<%= t('home.search_placeholder', site_name: TeSS::Config.site['title_short']) %>" ">
+      <button type="submit" class="searchbox-btn">
+        <i class="icon icon-h3 search-icon"></i>
+      </button>
+    </div>
+  <% end %>
+</div>

--- a/app/views/static/home/_welcome.html.erb
+++ b/app/views/static/home/_welcome.html.erb
@@ -5,16 +5,6 @@
     <p class="font-size-lg"><%== t 'home.subtitle' %></p>
   </div>
 
-  <%# Big search box %>
-  <div class="searchbox">
-    <%= form_tag search_path, method: :get, role: 'search' do %>
-      <div class="searchbox-wrapper">
-        <input type="text" class="searchbox-field" name="q"
-               placeholder= "<%= t('home.search_placeholder', site_name: TeSS::Config.site['title_short']) %>" autofocus="autofocus">
-        <button type="submit" class="searchbox-btn">
-          <i class="icon icon-h3 search-icon"></i>
-        </button>
-      </div>
-    <% end %>
-  </div>
+  <%= render partial: 'static/home/search_box' if TeSS::Config.site.dig('home_page', 'search_box') %>
+
 </section>

--- a/config/tess.example.yml
+++ b/config/tess.example.yml
@@ -112,6 +112,7 @@ default: &default
       latest_materials: # Number of materials on home page. Leave blank to turn off
       featured_trainer: false
       counters: false # Whether or not to show number of database objects in separate blocks
+      search_box: true # Whether or not to show the search box
     # The order in which the tabs appear (if feature enabled)
     tab_order: ['about', 'events', 'materials', 'elearning_materials', 'workflows', 'collections', 'trainers', 'content_providers', 'nodes']
     # The tabs that should be collapsed under the "Directory" tab. Can be left blank to hide it.

--- a/test/controllers/static_controller_test.rb
+++ b/test/controllers/static_controller_test.rb
@@ -72,7 +72,8 @@ class StaticControllerTest < ActionController::TestCase
       'provider_carousel': false,
       'featured_providers': nil,
       'faq': [],
-      'promo_blocks': false
+      'promo_blocks': false,
+      'search_box': false
     }
 
     with_settings({ site: site_settings }) do
@@ -81,6 +82,8 @@ class StaticControllerTest < ActionController::TestCase
       assert_select 'section#providers', count: 0
       assert_select 'section#faq', count: 0
       assert_select 'ul#promo-blocks', count: 0
+      assert_select 'ul#promo-blocks', count: 0
+      assert_select 'div.searchbox', count: 0
     end
 
     site_settings['home_page']['catalogue_blocks'] = true
@@ -90,6 +93,7 @@ class StaticControllerTest < ActionController::TestCase
       assert_select 'section#providers', count: 0
       assert_select 'section#faq', count: 0
       assert_select 'ul#promo-blocks', count: 0
+      assert_select 'div.searchbox', count: 0
     end
 
     site_settings['home_page']['provider_carousel'] = true
@@ -104,6 +108,7 @@ class StaticControllerTest < ActionController::TestCase
       assert_select 'section#providers .item a[href=?]', content_provider_path(provider2)
       assert_select 'section#faq', count: 0
       assert_select 'ul#promo-blocks', count: 0
+      assert_select 'div.searchbox', count: 0
     end
 
     site_settings['home_page']['faq'] = %w[who why]
@@ -114,6 +119,7 @@ class StaticControllerTest < ActionController::TestCase
       assert_select 'section#faq', count: 1
       assert_select 'section#faq .question', count: 2
       assert_select 'ul#promo-blocks', count: 0
+      assert_select 'div.searchbox', count: 0
     end
 
     site_settings['home_page']['promo_blocks'] = true
@@ -123,6 +129,17 @@ class StaticControllerTest < ActionController::TestCase
       assert_select 'section#providers', count: 1
       assert_select 'section#faq', count: 1
       assert_select 'ul#promo-blocks', count: 1
+      assert_select 'div.searchbox', count: 0
+    end
+
+    site_settings['home_page']['search_box'] = true
+    with_settings({ site: site_settings }) do
+      get :home
+      assert_select 'section#catalogue', count: 1
+      assert_select 'section#providers', count: 1
+      assert_select 'section#faq', count: 1
+      assert_select 'ul#promo-blocks', count: 1
+      assert_select 'div.searchbox', count: 1
     end
   end
 


### PR DESCRIPTION
Fixes #1122 

**Summary of changes**

- made the search box modular, see `app/views/static/home/_search_box.html.erb`
- in `tess.example.yml` there is now a `home_page.search_box` option.
- I added the relevant tests also to see whether 'searchbox' is present in html

**Motivation and context**

See #1122

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
