### PR TITLE
Customizable links on home and footer

### DIFF
--- a/app/views/about/us.html.erb
+++ b/app/views/about/us.html.erb
@@ -18,8 +18,10 @@
             <% if TeSS::Config.funders.present? %>
               <p>
                 <% TeSS::Config.funders.each do |funder| %>
-                  <%= link_to(funder['url'], target: '_blank', rel: 'noopener') do -%>
-                    <%= image_tag(funder['logo'], class: 'funding-logo') -%>
+                  <% unless funder[:only] && funder[:only] != 'about' %>
+                    <%= link_to(funder['url'], target: '_blank', rel: 'noopener') do -%>
+                      <%= image_tag(funder['logo'], class: 'funding-logo') -%>
+                    <% end %>
                   <% end %>
                 <% end %>
               </p>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -30,9 +30,11 @@
         <% end %>
         <% if TeSS::Config.site.dig('footer', 'additional_links') %>
            <% TeSS::Config.site.dig('footer', 'additional_links').each do |link| %>
-            <div class="footer-item">
-              <%= link_to link[:title], link[:url] %>
-            </div>
+            <% unless link[:on_right] %>
+              <div class="footer-item">
+                <%= link_to link[:title], link[:url] %>
+              </div>
+            <% end %>
           <% end %>
         <% end %>
        
@@ -55,6 +57,16 @@
           <div class="footer-item">
             <%= link_to t('footer.bioschemas_testing_tool'), bioschemas_test_path %>
           </div>
+        <% end %>
+
+        <% if TeSS::Config.site.dig('footer', 'additional_links') %>
+           <% TeSS::Config.site.dig('footer', 'additional_links').each do |link| %>
+            <% if link[:on_right] %>
+              <div class="footer-item">
+                <%= link_to link[:title], link[:url] %>
+              </div>
+            <% end %>
+          <% end %>
         <% end %>
       </div>
 

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -28,6 +28,14 @@
             <%= link_to t('footer.cookie_preferences'), cookies_consent_path %>
           </div>
         <% end %>
+        <% if TeSS::Config.site.dig('footer', 'additional_links') %>
+           <% TeSS::Config.site.dig('footer', 'additional_links').each do |link| %>
+            <div class="footer-item">
+              <%= link_to link[:title], link[:url] %>
+            </div>
+          <% end %>
+        <% end %>
+       
       </div>
 
       <div class="col-sm-4 col-xs-6 text-left">

--- a/app/views/layouts/_supported_by.erb
+++ b/app/views/layouts/_supported_by.erb
@@ -2,8 +2,10 @@
   <hr/>
   <div class="supporters">
     <%- TeSS::Config&.funders&.reverse&.each do |funder| %>
-      <%= link_to funder[:url], class: 'footer-logo', target: '_blank', rel: 'noopener' do %>
-        <%= image_tag(funder[:logo]) %>
+      <% unless funder[:only] && funder[:only] != 'footer' %>
+        <%= link_to funder[:url], class: 'footer-logo', target: '_blank', rel: 'noopener' do %>
+          <%= image_tag(funder[:logo]) %>
+        <% end %>
       <% end %>
     <% end %>
 

--- a/app/views/static/home.html.erb
+++ b/app/views/static/home.html.erb
@@ -27,6 +27,8 @@
 
   <%= render partial: 'static/home/welcome' %>
 
+  <%= render partial: 'static/home/additional_links' if TeSS::Config.site.dig('home_page', 'additional_links') %>
+
   <%= render partial: 'static/home/counters' if TeSS::Config.site.dig('home_page', 'counters') %>
 
   <%= render partial: 'static/home/catalogue_blocks' if TeSS::Config.site.dig('home_page', 'catalogue_blocks') %>

--- a/app/views/static/home/_additional_links.erb
+++ b/app/views/static/home/_additional_links.erb
@@ -1,7 +1,7 @@
 <section id="additional_links">
   <ul class="catalogue">
     <% TeSS::Config.site.dig('home_page', 'additional_links').each do |link| %>
-      <li class="resource-type">
+      <li class="resource-type" <%if link[:id] %> id="<%= link[:id] %>" <% end %>>
         <%= link_to link[:url], class: 'link-overlay' do %>
           <div class="resource-type-title">
             <%= image_tag(link[:icon], alt: link[:title]) %>

--- a/app/views/static/home/_additional_links.erb
+++ b/app/views/static/home/_additional_links.erb
@@ -1,0 +1,14 @@
+<section id="additional_links">
+  <ul class="catalogue">
+    <% TeSS::Config.site.dig('home_page', 'additional_links').each do |link| %>
+      <li class="resource-type">
+        <%= link_to link[:url], class: 'link-overlay' do %>
+          <div class="resource-type-title">
+            <%= image_tag(link[:icon], alt: link[:title]) %>
+            <h3><%= link[:title] %></h3>
+          </div>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+</section>

--- a/app/views/static/home/_additional_links.erb
+++ b/app/views/static/home/_additional_links.erb
@@ -1,8 +1,13 @@
 <section id="additional_links">
   <ul class="catalogue">
     <% TeSS::Config.site.dig('home_page', 'additional_links').each do |link| %>
+      <% link_options = { class: 'link-overlay' } %>
+      <% if link[:new_tab] %>
+          <% link_options[:target] = '_blank' %>
+          <% link_options[:rel] = 'noopener' %>
+      <% end %>
       <li class="resource-type" <%if link[:id] %> id="<%= link[:id] %>" <% end %>>
-        <%= link_to link[:url], class: 'link-overlay' do %>
+        <%= link_to link[:url], link_options do %>
           <div class="resource-type-title">
             <%= image_tag(link[:icon], alt: link[:title]) %>
             <h3><%= link[:title] %></h3>

--- a/app/views/static/home/_space_welcome.html.erb
+++ b/app/views/static/home/_space_welcome.html.erb
@@ -1,4 +1,4 @@
-<section>
+<section id="space_welcome_text">
   <%# Welcome text %>
   <div class="welcome-text">
     <h1 class="module-heading"><%= current_space.title %></h1>

--- a/app/views/static/home/_welcome.html.erb
+++ b/app/views/static/home/_welcome.html.erb
@@ -1,4 +1,4 @@
-<section>
+<section id="welcome_text">
   <%# Welcome text %>
   <div class="welcome-text">
     <h1 class="module-heading"><%== t 'home.welcome' %></h1>

--- a/config/tess.example.yml
+++ b/config/tess.example.yml
@@ -114,6 +114,16 @@ default: &default
       featured_trainer: false
       counters: false # Whether or not to show number of database objects in separate blocks
       search_box: true # Whether or not to show the search box
+      additional_links: # Add custom links in separate blocks
+#       - url: https://example.com/
+#         icon: placeholder-person.png  # Path relative to app/assets/images or absolute URL
+#         title: "My Example Link"
+#         id: example-link  # Optional id for custom styling in theme
+    footer: # Configuration for the footer
+      additional_links: # Add custom links to the footer
+#        - url: https://example.com/
+#          title: Example
+#          on_right: False # Display link in right column of footer, defaults to False 
     # The order in which the tabs appear (if feature enabled)
     tab_order: ['about', 'events', 'materials', 'elearning_materials', 'workflows', 'collections', 'trainers', 'content_providers', 'nodes']
     # The tabs that should be collapsed under the "Directory" tab. Can be left blank to hide it.

--- a/config/tess.example.yml
+++ b/config/tess.example.yml
@@ -119,11 +119,12 @@ default: &default
 #         icon: placeholder-person.png  # Path relative to app/assets/images or absolute URL
 #         title: "My Example Link"
 #         id: example-link  # Optional id for custom styling in theme
+#         new_tab: false # Open link in new tab, defaults to false
     footer: # Configuration for the footer
       additional_links: # Add custom links to the footer
 #        - url: https://example.com/
 #          title: Example
-#          on_right: False # Display link in right column of footer, defaults to False 
+#          on_right: false # Display link in right column of footer, defaults to false 
     # The order in which the tabs appear (if feature enabled)
     tab_order: ['about', 'events', 'materials', 'elearning_materials', 'workflows', 'collections', 'trainers', 'content_providers', 'nodes']
     # The tabs that should be collapsed under the "Directory" tab. Can be left blank to hide it.

--- a/config/tess.example.yml
+++ b/config/tess.example.yml
@@ -223,6 +223,7 @@ default: &default
   funders:
 #    - url: https://example.com/your-funders-website
 #      logo: foo.png
+#      only: # "footer" or "about" - if pressent, show funder only in specified location
   priority_licences:
     - MIT
     - Apache-2.0


### PR DESCRIPTION
**Summary of changes**

Configurable arbitrary links

- in footer
- as boxes on home screen including some icon or logo
- extended funder logos on footer and about/us by option to only show logo in either place
  - e.g. to have the dark version of a logo in the footer while the light version is on the about/us page
  - e.g. to only have logo on about/us page if there are too many

Also adds an html id attribute to the sections on the screen where it is still missing. 

**Motivation and context**

Part of mTeSS-x project to allow further customization of different instances. (In particular relevant for [PaN Training](https://pan-training.eu/) to allow imprint link in footer and links to wiki and e-learning on home.)
 
**Screenshots**

The example contains the configured links "Access Courses", "PaN Wiki" and "Test":
![image](https://github.com/user-attachments/assets/49871b7a-b1cd-49c7-bc0b-1a5a30bfaa13)

The example contains the configured links "Imprint" and "Test"
![Screenshot from 2025-07-09 12-11-14](https://github.com/user-attachments/assets/e6cfe813-3977-4714-a2c3-d8ac5bc2e91f)

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
