### PR TITLE
docker-compose-prod with tmp shared

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -21,6 +21,7 @@ services:
     volumes:
       - uploads:/code/public/system
       - logs:/code/log
+      - tmp:/code/tmp
       - ./config/tess.yml:/code/config/tess.yml
       - ./config/secrets.yml:/code/config/secrets.yml
     environment:
@@ -80,6 +81,7 @@ services:
       - redis
     volumes:
       - uploads:/code/public/system
+      - tmp:/code/tmp
       - ./config/tess.yml:/code/config/tess.yml
       - ./config/secrets.yml:/code/config/secrets.yml
     env_file: .env


### PR DESCRIPTION
**Summary of changes**

- Adding /tmp as a shared volume with app and sidekiq

**Motivation and context**

- While running source test on prod, the running test finishes with a "There was a problem rendering the results.", the results file (test_results_#{id}.yml) was in tmp on the sidekiq instance, but not in the tess instance. @fbacall confirmed /tmp should be on a shared volume. Then while doing the test on a local docker I can see that the test_results.yml is found in both /tmp but this is explained by the shared ./code volume between app and sidekiq (see [docker-compose.yml](https://github.com/ElixirTeSS/TeSS/blob/master/docker-compose.yml)). However in [docker-compose-prod.yml](https://github.com/ElixirTeSS/TeSS/blob/master/docker-compose-prod.yml) it is /code/public/system which is shared between app and sidekiq and not /tmp. Fixing it now.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
