### PR TITLE
FrozenError on profile/user delete

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -9,7 +9,7 @@ class Profile < ApplicationRecord
   validates :website, url: true, http_url: { allow_inaccessible: true }, allow_blank: true
   validates :orcid, orcid: true, allow_blank: true
   after_validation :check_public
-  after_commit :reindex_trainer
+  after_commit :reindex_trainer, on: %i[create update]
   clean_array_fields(:expertise_academic, :expertise_technical, :fields,
                      :interest, :activity, :language, :social_media)
   update_suggestions(:expertise_technical, :interest)


### PR DESCRIPTION
**Summary of changes**

- `profile.rb`: calling reindex_trainer only when creating and updating, not deleting.

**Motivation and context**

When deleting a user, a FrozenError was raised, this is due to the `reindex_trainer` method of the `Profile` model being called after a commit.

**Discussions**

One question raised by Finn was *"we need to check what happens to the search index when the profile is deleted (e.g. does it cause an error because the profile is returned from the search service but can't be found in the database anymore)"*

1. Register user, delete immediately:
  a. They are present in table users, not in table profiles, not in solr
  b. Deleting does the FrozenError
  c. Then they are not present in db anymore (nor in solr)
 2. Register user, update profile, not ticking trainer
  a. Present in Profile solr search (in rails console, Profile.where)
  b. Deleting does the FrozenError, then not present in solr search (Profile)
3. Register user, update profile as trainer:
  a. After updating as a trainer, they are present in a Trainers solr search (in rails console, Trainer.search { fulltext 'Kenneth' }.results)
  b. Deleting does the FrozenError, then they are both not present in db and in solr search (either in Trainer nor in Profile)

Redoing it with the amended callback `after_commit :reindex_trainer, on: %i[create update]`
1. Register user, delete immediately:
  a. Not found in Solr search
  b. After deleting, no more FE
  c. Not present in db nor solr search
2. Register user, update firstname and surname, not ticking trainer
  a. Not found in Solr search (Profile and Trainer)
  b. After deleting, no more FE
  c. Not present in db nor solr search
3. Register user, ticking trainer
  a. Searchable through Trainer.search
  b. After deleting, no FE
  c. Not present in db, and Trainer.search does not find anything

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
