### PR TITLE
Enhance Bioschemas serialization

### DIFF
--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -61,6 +61,13 @@ class Node < ApplicationRecord
     Material.where(id: provider_material_ids | material_ids)
   end
 
+  def full_title
+    return title if title == 'EMBL-EBI'
+    t = title
+    t = 'UK' if title == 'United Kingdom'
+    I18n.t('nodes.full_title', title: t)
+  end
+
   def self.load_from_hash(hash, verbose: false)
     hash["nodes"].map do |node_data|
       node = Node.find_or_initialize_by(name: node_data["name"])

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -875,6 +875,8 @@ en:
     hints:
       hide_child_nodes: Ticking this box will hide child nodes from the diagram until their parent node is clicked.
       public: Un-ticking this box will hide this workflow from anyone who isn't the creator or a collaborator.
+  nodes:
+    full_title: 'ELIXIR %{title}'
   menu:
     user:
       my_profile: 'My profile'

--- a/lib/bioschemas/course_generator.rb
+++ b/lib/bioschemas/course_generator.rb
@@ -14,6 +14,7 @@ module Bioschemas
     property :description, :description
     property :keywords, :keywords
     property :provider, -> (event) { event.host_institutions.map { |i| { '@type' => 'Organization', name: i } } }
+    property :inLanguage, :language
     property :audience, -> (event) {
       event.target_audience.map { |audience| { '@type' => 'Audience', 'audienceType' => audience } }
     }
@@ -23,5 +24,12 @@ module Bioschemas
     property :hasCourseInstance, -> (event) {
       [Bioschemas::CourseInstanceGenerator.new(event).generate.except('@id')]
     }
+    property :coursePrerequisites, -> (event) {
+      markdown_to_array(event.prerequisites)
+    }
+    property :teaches, -> (event) {
+      markdown_to_array(event.learning_objectives)
+    }
+    property :mentions, -> (material) { external_resources(material) }
   end
 end

--- a/lib/bioschemas/generator.rb
+++ b/lib/bioschemas/generator.rb
@@ -148,7 +148,7 @@ module Bioschemas
         p << {
           '@type' => 'Organization',
           'name' => node.full_title,
-          'url' => node.url
+          'url' => node.home_page
         }
       end
 

--- a/lib/bioschemas/generator.rb
+++ b/lib/bioschemas/generator.rb
@@ -101,5 +101,58 @@ module Bioschemas
         'longitude' => event.longitude
       }.compact
     end
+
+    # Reverse the process used by TeSS_RDF_Extractors to turn a list of values into a markdown list.
+    # If the input doesn't look listy, falls back to just returning a list containing the input value as a single element.
+    # Note that this could lose some data in the case that the input markdown starts with a list and then has some
+    # non-list content afterwards.
+    def self.markdown_to_array(markdown)
+      return nil if markdown.blank?
+      a = []
+
+      if markdown.start_with?(' * ')
+        matches = markdown.scan(/ \* (.+)\n/)
+        if matches.any?
+          a += matches.flatten
+        else
+          a << markdown
+        end
+      else
+        a << markdown
+      end
+
+      a.any? ? a : nil
+    end
+
+    def self.external_resources(resource)
+      resource.external_resources.map do |ext_res|
+        {
+          '@type' => 'Thing',
+          'name' => ext_res.title,
+          'url' => ext_res.url
+        }
+      end
+    end
+
+    def self.provider(resource)
+      p = []
+      if resource.content_provider
+        p << {
+          '@type' => 'Organization',
+          'name' => resource.content_provider.title,
+          'url' => resource.content_provider.url
+        }
+      end
+
+      resource.nodes.each do |node|
+        p << {
+          '@type' => 'Organization',
+          'name' => node.full_title,
+          'url' => node.url
+        }
+      end
+
+      p.any? ? p : nil
+    end
   end
 end

--- a/lib/bioschemas/learning_resource_generator.rb
+++ b/lib/bioschemas/learning_resource_generator.rb
@@ -9,7 +9,10 @@ module Bioschemas
     end
 
     property :name, :title
+    property :learningResourceType, :resource_type
     property :url, :url
+    property :identifier, :doi
+    property :verison, :version
     property :description, :description
     property :keywords, :keywords
     property :author, -> (material) { material.authors.map { |p| person(p) } }
@@ -20,14 +23,24 @@ module Bioschemas
     property :about, -> (material) {
       material.scientific_topics.map { |t| term(t) }
     }
-    property :dateCreated, :remote_created_date
-    property :dateModified, :remote_updated_date
+    property :dateCreated, :date_created
+    property :dateModified, :date_modified
+    property :datePublished, :date_published
+    property :creativeWorkStatus, :status
     property :license, -> (material) {
       LicenceDictionary.instance.lookup_value(material.licence, 'reference') ||
         LicenceDictionary.instance.lookup_value(material.licence, 'url') ||
         material.licence
     }
     property :educationalLevel, :difficulty_level,
-             condition: -> (event) { event.difficulty_level != 'notspecified' }
+             condition: -> (material) { material.difficulty_level != 'notspecified' }
+    property :competencyRequired, -> (material) {
+      markdown_to_array(material.prerequisites)
+    }
+    property :teaches, -> (material) {
+      markdown_to_array(material.learning_objectives)
+    }
+    property :mentions, -> (material) { external_resources(material) }
+    property :provider, -> (material) { provider(material) }
   end
 end

--- a/lib/bioschemas/learning_resource_generator.rb
+++ b/lib/bioschemas/learning_resource_generator.rb
@@ -17,6 +17,7 @@ module Bioschemas
     property :keywords, :keywords
     property :author, -> (material) { material.authors.map { |p| person(p) } }
     property :contributor, -> (material) { material.contributors.map { |p| person(p) } }
+    property :provider, -> (material) { provider(material) }
     property :audience, -> (material) {
       material.target_audience.map { |audience| { '@type' => 'Audience', 'audienceType' => audience } }
     }
@@ -41,6 +42,5 @@ module Bioschemas
       markdown_to_array(material.learning_objectives)
     }
     property :mentions, -> (material) { external_resources(material) }
-    property :provider, -> (material) { provider(material) }
   end
 end

--- a/lib/bioschemas/learning_resource_generator.rb
+++ b/lib/bioschemas/learning_resource_generator.rb
@@ -12,7 +12,7 @@ module Bioschemas
     property :learningResourceType, :resource_type
     property :url, :url
     property :identifier, :doi
-    property :verison, :version
+    property :version, :version
     property :description, :description
     property :keywords, :keywords
     property :author, -> (material) { material.authors.map { |p| person(p) } }

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -479,9 +479,11 @@ course_event:
   contact: MyContact
   eligibility: [ first_come_first_served ]
   timezone: UTC
-  learning_objectives: "There are none."
+  learning_objectives: " * Learn stuff\n * Get a job\n * Get paid\n"
+  prerequisites: " * Sleep\n * Eat\n * Breathe\n"
   recognition: "Yup. You attended the workshop."
   target_audience: ['Everyone!']
+  language: 'de'
 
 hybrid_event:
   presence: 2

--- a/test/fixtures/materials.yml
+++ b/test/fixtures/materials.yml
@@ -138,9 +138,9 @@ material_with_optionals:
   subsets: [ 'https://training.com/material/023/part-one', 'https://training.com/material/023/part-two' ]
   authors: [ 'Nicolai Tesla', 'Thomas Edison' ]
   contributors: [ 'Dr Dre' ]
-  prerequisites: 'None'
+  prerequisites: " * None\n * Nothing at all\n"
   syllabus: '1. Overview\  2. The main part\  3. Summing up'
-  learning_objectives: 'Understand the new materials model'
+  learning_objectives: ' - Understand the new materials model'
   difficulty_level: intermediate
   remote_created_date: 2021-07-12
   remote_updated_date: 2021-07-13

--- a/test/models/material_test.rb
+++ b/test/models/material_test.rb
@@ -60,9 +60,9 @@ class MaterialTest < ActiveSupport::TestCase
     assert_equal 1, m.contributors.size, 'old contributors size not matched.'
     assert_equal 'Dr Dre', m.contributors[0], 'old contributors[0] not matched.'
 
-    assert_equal 'None', m.prerequisites, 'old prerequisites not matched.'
+    assert_equal " * None\n * Nothing at all\n", m.prerequisites, 'old prerequisites not matched.'
     assert_equal '1. Overview\  2. The main part\  3. Summing up', m.syllabus, 'old syllabus not matched.'
-    assert_equal 'Understand the new materials model', m.learning_objectives, 'old learning objectives not matched.'
+    assert_equal ' - Understand the new materials model', m.learning_objectives, 'old learning objectives not matched.'
 
     # update optionals
     m.content_provider = content_providers(:iann)

--- a/test/models/node_test.rb
+++ b/test/models/node_test.rb
@@ -121,6 +121,13 @@ class NodeTest < ActiveSupport::TestCase
     assert node.valid?
   end
 
+  test 'full title' do
+    assert_equal 'ELIXIR Sweden', Node.new(title: 'Sweden').full_title
+    assert_equal 'ELIXIR UK', Node.new(title: 'United Kingdom').full_title
+    assert_equal 'EMBL-EBI', Node.new(title: 'EMBL-EBI').full_title
+    assert_equal 'ELIXIR Westeros', nodes(:westeros).full_title
+  end
+
   private
 
   def node_data_hash


### PR DESCRIPTION
**Summary of changes**

Extends the Bioschemas JSON-LD present on show/index pages with some extra properties:

*LearningResource (Material)*
- learningResourceType
- identifier
- version
- dateCreated
- dateModified
- datePublished
- creativeWorkStatus
- competencyRequired
- teaches
- mentions
- provider

*Course/CourseInstance (Event)*
- inLanguage
- coursePrerequisites
- teaches
- mentions

**Motivation and context**

Some of the Bioschemas properties that TeSS was ingesting were not reflected back in its own Bioschemas serialization.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
