### PR TITLE
Google sheet material ingestion

### DIFF
--- a/test/unit/ingestors/material_csv_ingestor_test.rb
+++ b/test/unit/ingestors/material_csv_ingestor_test.rb
@@ -205,6 +205,23 @@ class MaterialCsvIngestorTest < ActiveSupport::TestCase
     assert_equal description, updated.description, 'Updated description has changed!'
   end
 
+  test 'should change url to google sheet export if needed' do
+    ingestor = Ingestors::MaterialCsvIngestor.new
+
+    url_random = 'https://this-might-not-be-reachable-at-all.com'
+    url_not_spreadsheet = 'https://google.com'
+    url_spreadsheet = 'https://docs.google.com/spreadsheets/d/abcde/edit?gid=12345#gid=12345'
+    url_export_spreadsheet = 'https://docs.google.com/spreadsheets/d/abcde/export?gid=12345&exportFormat=csv'
+
+    # doesn't change url, because not google spreadsheet
+    assert_equal ingestor.send(:gsheet_to_csv, url_random), url_random
+    assert_equal ingestor.send(:gsheet_to_csv, url_not_spreadsheet), url_not_spreadsheet
+
+    # do change url, because google spreadsheet
+    assert_equal ingestor.send(:gsheet_to_csv, url_spreadsheet), url_export_spreadsheet
+    assert_not_equal url_spreadsheet, url_export_spreadsheet
+  end
+
   private
 
   def get_material(title, url, provider = nil)


### PR DESCRIPTION
**Summary of changes**

- `lib/ingestors/material_csv_ingestor.rb`: modify the given url to a Google sheet csv export URL if it has`docs.google.com/spreadsheets` – the rest is taken care of the csv ingestor as usual.

**Motivation and context**

After a discussion with Phil and Finn when I presented the following workflow (see https://github.com/EVERSE-ResearchSoftware/training):

1. Through a GH action, exporting google sheet csv
2. Translating to a JSON-LD format
3. Push the changes on the GH repo to have TeSS fetching the metadata on the raw JSON-LD file

Finn asked whether it would be possible to do it in TeSS directly. Here it is.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
