### PR TITLE
Reindex resource when link status changes

### DIFF
--- a/app/models/link_monitor.rb
+++ b/app/models/link_monitor.rb
@@ -41,8 +41,8 @@ class LinkMonitor < ApplicationRecord
 
   def status_changed?
     prev_count = fail_count_previously_was || 0
-    prev_count >= FAILURE_THRESHOLD && fail_count == 0 ||
-      prev_count < FAILURE_THRESHOLD && failing?
+    (prev_count >= FAILURE_THRESHOLD && fail_count == 0) ||
+      (prev_count < FAILURE_THRESHOLD && failing?)
   end
 
   private

--- a/app/models/link_monitor.rb
+++ b/app/models/link_monitor.rb
@@ -1,6 +1,7 @@
 class LinkMonitor < ApplicationRecord
   belongs_to :link_checkable, polymorphic: true, foreign_key: :lcheck_id, foreign_type: :lcheck_type
   before_create :set_initial_date
+  after_commit :reindex_resource, on: :update
 
   FAILURE_THRESHOLD = 4
 
@@ -36,5 +37,19 @@ class LinkMonitor < ApplicationRecord
 
   def failing?
     fail_count >= FAILURE_THRESHOLD
+  end
+
+  def status_changed?
+    prev_count = fail_count_previously_was || 0
+    prev_count >= FAILURE_THRESHOLD && fail_count == 0 ||
+      prev_count < FAILURE_THRESHOLD && failing?
+  end
+
+  private
+
+  def reindex_resource
+    return unless TeSS::Config.solr_enabled
+    return unless status_changed?
+    link_checkable.solr_index
   end
 end

--- a/test/models/link_monitor_test.rb
+++ b/test/models/link_monitor_test.rb
@@ -96,4 +96,24 @@ class LinkMonitorTest < ActiveSupport::TestCase
     refute @link_monitor.failing?
     assert_equal 0, @link_monitor.fail_count
   end
+
+  test 'link monitor status changed' do
+    refute @link_monitor.status_changed?
+
+    @link_monitor.update_column(:fail_count, 3)
+    refute @link_monitor.failing?
+    refute @link_monitor.status_changed?
+
+    @link_monitor.fail!(404)
+    assert @link_monitor.failing?
+    assert @link_monitor.status_changed?
+
+    @link_monitor.fail!(404)
+    assert @link_monitor.failing?
+    refute @link_monitor.status_changed?
+
+    @link_monitor.success
+    refute @link_monitor.failing?
+    assert @link_monitor.status_changed?
+  end
 end

--- a/test/models/link_monitor_test.rb
+++ b/test/models/link_monitor_test.rb
@@ -112,8 +112,12 @@ class LinkMonitorTest < ActiveSupport::TestCase
     assert @link_monitor.failing?
     refute @link_monitor.status_changed?
 
-    @link_monitor.success
+    @link_monitor.success!
     refute @link_monitor.failing?
     assert @link_monitor.status_changed?
+
+    @link_monitor.success!
+    refute @link_monitor.failing?
+    refute @link_monitor.status_changed?
   end
 end


### PR DESCRIPTION
**Summary of changes**

- Trigger a reindex of an event/material if its URL is detected as being broken (or back online)

**Motivation and context**

Resources with dead links were showing up in search results due to not being indexed after the link monitor updated.
 
**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
