### PR TITLE
Add some code to facilitating the debugging of bad test data from a source

### DIFF
--- a/app/views/sources/_test_resource_error.html.erb
+++ b/app/views/sources/_test_resource_error.html.erb
@@ -1,0 +1,9 @@
+<div class="list-card bulk-import-row alert alert-danger">
+  <h4><%= "#{t('sources.testing.error.title')} (#{resource_type})" %></h4>
+  <p class="pt-2">
+    <div><%= t('sources.testing.error.input_data') %></div>
+    <pre><%= JSON.pretty_generate(resource_params) %></pre>
+    <div><%= "#{t('sources.testing.error.message')} #{exception.message}" %></div>
+    <pre><%= exception.backtrace.first(3).join('<br>').html_safe %></pre>
+  </p>
+</div>

--- a/app/views/sources/_test_resource_error.html.erb
+++ b/app/views/sources/_test_resource_error.html.erb
@@ -1,9 +1,11 @@
 <div class="list-card bulk-import-row alert alert-danger">
   <h4><%= "#{t('sources.testing.error.title')} (#{resource_type})" %></h4>
-  <p class="pt-2">
-    <div><%= t('sources.testing.error.input_data') %></div>
-    <pre><%= JSON.pretty_generate(resource_params) %></pre>
-    <div><%= "#{t('sources.testing.error.message')} #{exception.message}" %></div>
-    <pre><%= exception.backtrace.first(3).join('<br>').html_safe %></pre>
-  </p>
+  <% if current_user&.is_admin? %>
+    <p class="pt-2">
+      <div><%= t('sources.testing.error.input_data') %></div>
+      <pre><%= JSON.pretty_generate(resource_params) %></pre>
+      <div><%= "#{t('sources.testing.error.message')} #{exception.message}" %></div>
+      <pre><%= exception.backtrace.first(3).join('<br>').html_safe %></pre>
+    </p>
+  <% end %>
 </div>

--- a/app/views/sources/_test_results.html.erb
+++ b/app/views/sources/_test_results.html.erb
@@ -28,9 +28,17 @@
       Showing <%= pluralize(sample.count, 'sample') %>
     <% end %>
     <% sample.each do |resource_params| %>
-      <% resource = Source.get_test_resource(type, resource_params, user: User.get_default_user,
-                                                                    content_provider: @content_provider) %>
-      <%= render partial: 'sources/test_resource', locals: { resource: resource, resource_params: resource_params } %>
+      <% begin %>
+        <% resource = Source.get_test_resource(type, resource_params, user: User.get_default_user,
+                                                                      content_provider: @content_provider) %>
+        <%= render partial: 'sources/test_resource', locals: { resource: resource,
+                                                               resource_params: resource_params } %>
+      <% rescue StandardError => e %>
+        <%= render partial: 'sources/test_resource_error',
+            locals: { resource_params: resource_params,
+                      resource_type: type,
+                      exception: e } %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -818,6 +818,11 @@ en:
       filters: Filters
       allow_list: Allow List
       block_list: Block List
+    testing:
+      error:
+        title: "Error rendering test ingestion!"
+        input_data: "Input data:"
+        message: "Error message:"
     prompts:
       default_language: 'Select a default language...'
   scraper:


### PR DESCRIPTION
In particular, don't let the `sources/show` page crash with a 500.

**Summary of changes**

Before, if you are testing a source and you pull in some bad data that won't render, you are stuck and you can't see the page related to your source until you delete the file pointed by `test_results_path`.

<img width="752" height="781" alt="source_test_before" src="https://github.com/user-attachments/assets/0e46be49-33df-4e4d-9aaf-8461a9115c38" />

This is particularly problematic if you don't have access to the back end. In production, the only clue you have is a message saying "500 Internal Server Error".

With this change, not only will the server not throw a 500, it will show some information on the `#testing` tab for the source that might help fix things (and will give you access to the `show` page for the source again.

<img width="819" height="1166" alt="source_test_after" src="https://github.com/user-attachments/assets/d3c4ee83-dad8-4294-9dcc-985e6946fc64" />

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree to license it to the TeSS codebase under the [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
