### PR TITLE
add link to main application in error messages for private spaces

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -181,10 +181,10 @@ class ApplicationController < ActionController::Base
     if TeSS::Config.feature['spaces'] && Space.current_space != Space.default
       unless policy(Space.current_space).shown?
         if current_user
-          flash[:alert] = t('private_space.no_authorized')
+          flash[:alert] = t('private_space.no_authorized', base_url: TeSS::Config.base_url).html_safe
           raise Pundit::NotAuthorizedError
         else
-          flash[:alert] = t('private_space.needs_sign_in')
+          flash[:alert] = t('private_space.needs_sign_in', base_url: TeSS::Config.base_url).html_safe
           raise Pundit::NotAuthorizedError
         end
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,7 +50,7 @@ en:
       <br><a href="%{base_url}">Return to the main application</a>
     needs_sign_in: >
       You need to sign in to the main application to access this page.
-      <br><a href="%{base_url}">Return to the main application</a>
+      <br><a href="%{base_url}/users/sign_in">Sign in to the main application</a>
     needs_groups_in_form: If the space is private, you must add required groups.
   group:
     show:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,8 +45,12 @@ en:
     material_policy:
     event_policy:
   private_space:
-    no_authorized: You are not authorized to access this page.
-    needs_sign_in: You need to sign in to the main application to access this page.
+    no_authorized: >
+      You are not authorized to access this page.
+      <br><a href="%{base_url}">Return to the main application</a>
+    needs_sign_in: >
+      You need to sign in to the main application to access this page.
+      <br><a href="%{base_url}">Return to the main application</a>
     needs_groups_in_form: If the space is private, you must add required groups.
   group:
     show:


### PR DESCRIPTION
**Summary of changes**

- add a link to the main instance when you have an error while accessing a private space

**Motivation and context**

If a user try to access directly a private space without sign in or without enough rights, they get an error and need to change the URL by hand to go to the main application.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree to license it to the TeSS codebase under the [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
