### PR TITLE
Private space UI update

### DIFF
--- a/app/views/spaces/_space.html.erb
+++ b/app/views/spaces/_space.html.erb
@@ -12,6 +12,19 @@
 
       <span class="muted"><%= space.url %></span>
 
+      <br>
+
+      <% if space.administrators.any? %>
+        <span class="muted">Administrators: <%= space.administrators.pluck(:username).join(", ") %></span>
+        <br>
+      <% end %>
+
+      <% if space.is_private %>
+        <div class="muted" style="display: inline;">
+          Groups authorized: <%= space.groups.pluck(:title).join(", ") %>
+        </div>
+      <% end %>
+
       <% if space.materials.length > 0 %>
         <div><strong><%= pluralize(space.materials.length, 'training material') %></strong></div>
       <% end %>

--- a/app/views/spaces/_space.html.erb
+++ b/app/views/spaces/_space.html.erb
@@ -5,6 +5,9 @@
       <%= image_tag get_image_url_for(space), class: "media-image listing_image pull-right space-logo", style: (theme_colour ? "background-color: #{theme_colour}" : nil) %>
       <h4 class="mb-2 mt-3" style="<%= theme_colour ? "color: #{theme_colour}" : ''-%>">
         <%= space.title %>
+        <% if space.is_private %>
+          <i class='glyphicon glyphicon-lock' style="font-size: 18px; margin-left: 5px"></i>
+        <% end %>
       </h4>
 
       <span class="muted"><%= space.url %></span>

--- a/app/views/spaces/show.html.erb
+++ b/app/views/spaces/show.html.erb
@@ -29,6 +29,16 @@
       <div class="my-3">
         <%= display_attribute(@space, :url) %>
 
+        <% if @space.administrators.any? %>
+          <p><div class="text-primary">Administrators:</div> <%= @space.administrators.pluck(:username).join(", ") %></p>
+        <% end %>
+
+        <% if @space.is_private %>
+          <div style="display: inline;">
+            <span class="text-primary">Groups authorized:</span> <%= @space.groups.pluck(:title).join(", ") %>
+          </div>
+        <% end %>
+
         <div class="description">
           <%= render_markdown @space.description %>
         </div>


### PR DESCRIPTION
**Summary of changes**

- adding information on a space page and on the index page for spaces to see privacy-related information.

**Motivation and context**

A user can't check if a space he can see is private or not, who are the administrators and which group is necessary to access it. The only way is to have access to the edition form.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree to license it to the TeSS codebase under the [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
