### PR TITLE
Configurable filter limit for anonymous users

### DIFF
--- a/app/assets/stylesheets/base/_facets.scss
+++ b/app/assets/stylesheets/base/_facets.scss
@@ -56,7 +56,7 @@ ul.unstyled {
   width: 100%;
 }
 
-.nav-item > a {
+.nav-item > a, .nav-item > span {
   position: relative;
   display: block;
   color: #333;

--- a/app/controllers/concerns/searchable_index.rb
+++ b/app/controllers/concerns/searchable_index.rb
@@ -20,6 +20,7 @@ module SearchableIndex
   included do
     attr_reader :facet_fields, :search_params, :facet_params, :page, :sort_by, :index_resources
     before_action :set_params, only: [:index, :count]
+    before_action :limit_filters
     before_action :fetch_resources, only: [:index, :count]
 
     helper 'search'
@@ -140,5 +141,12 @@ module SearchableIndex
   #           building pagination/self links.
   def search_and_facet_params
     params.permit(*(@model.search_and_facet_keys | [:page_size, :page_number, :page, :per_page]))
+  end
+
+  def limit_filters
+    if !request.format.json? && !request.format.json_api? && current_user.nil? && @facet_params&.values &&
+      TeSS::Config.filter_limit && @facet_params.values.flatten.length > TeSS::Config.filter_limit
+      handle_error(400, t('search.errors.filter_limit_reached'))
+    end
   end
 end

--- a/app/controllers/concerns/searchable_index.rb
+++ b/app/controllers/concerns/searchable_index.rb
@@ -20,7 +20,7 @@ module SearchableIndex
   included do
     attr_reader :facet_fields, :search_params, :facet_params, :page, :sort_by, :index_resources
     before_action :set_params, only: [:index, :count]
-    before_action :limit_filters
+    before_action :limit_filters, only: [:index, :count]
     before_action :fetch_resources, only: [:index, :count]
 
     helper 'search'

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -29,13 +29,19 @@ module SearchHelper
     parameters.delete('page') #remove the page option if it exists
     html_options.reverse_merge!(title: value.to_s)
 
-    link_to parameters, html_options do
+    content = -> do
       if block_given?
         block.call
       else
         content_tag(:span, facet_title(name, value, html_options), class: 'facet-label') +
           content_tag(:span, "#{count}", class: 'facet-count')
       end
+    end
+
+    if filter_limit_reached?
+      content_tag(:span, class: 'facet-option filter-limit-reached', &content)
+    else
+      link_to parameters, html_options, &content
     end
   end
 
@@ -74,5 +80,10 @@ module SearchHelper
             Show fewer #{facet.humanize.pluralize.downcase}</span>
             <i class='glyphicon glyphicon-chevron-up pull-right toggle-#{facet}' style='display: none;'></i>
             ".html_safe
+  end
+
+  def filter_limit_reached?
+    current_user.nil? && @facet_params&.values && TeSS::Config.filter_limit &&
+      @facet_params.values.flatten.length >= TeSS::Config.filter_limit
   end
 end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -39,7 +39,9 @@ module SearchHelper
     end
 
     if filter_limit_reached?
-      content_tag(:span, class: 'facet-option filter-limit-reached', &content)
+      html_options[:class] = [html_options[:class], 'filter-limit-reached'].compact.join(' ')
+
+      content_tag(:span, html_options, &content)
     else
       link_to parameters, html_options, &content
     end

--- a/app/views/search/common/_facet_sidebar_boolean_filter.html.erb
+++ b/app/views/search/common/_facet_sidebar_boolean_filter.html.erb
@@ -19,7 +19,7 @@
   <li class="toggle-wrap mb-2 nav-item">
     <%= filter_link(facet_field, 'true', count) do %>
       <label class="toggle">
-        <input type="checkbox">
+        <input type="checkbox" <%= 'disabled' if filter_limit_reached? -%>>
         <span class="slider round"></span>
       </label>
       <%= enable_text %>

--- a/app/views/search/common/_search_panel.html.erb
+++ b/app/views/search/common/_search_panel.html.erb
@@ -21,6 +21,9 @@
         <%= content_for(:display_options) %>
       </div>
       <% if TeSS::Config.solr_enabled %>
+        <% if filter_limit_reached? %>
+          <div class="alert alert-info mb-3"><%= t('search.errors.filter_limit_reached') %></div>
+        <% end %>
         <div class="hidden-xs">
           <%= render partial: 'search/common/search_filters', locals: { resources: resources } %>
         </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1198,7 +1198,6 @@ en:
           A user being part of a group has access to every private space which requires the group.
           Each group has multiple owners. A owner can add and remove people to the group.
   orcid:
-  orcid:
     error: 'An error occurred whilst trying to authenticate your ORCID.'
     link: 'Link your ORCID'
     authenticate: 'Authenticate your ORCID'
@@ -1241,3 +1240,6 @@ en:
     link: Go to original entry
   other_space:
     link: View in space
+  search:
+    errors:
+      filter_limit_reached: Filter limit reached, please log in to apply additional filters.

--- a/config/tess.example.yml
+++ b/config/tess.example.yml
@@ -288,6 +288,7 @@ default: &default
     space:
       primary: '#260252'
       secondary: '#5c29b1'
+  filter_limit: # Maximum number filter values allowed for anonymous users
 development:
   <<: *default
 

--- a/config/tess.example.yml
+++ b/config/tess.example.yml
@@ -288,7 +288,7 @@ default: &default
     space:
       primary: '#260252'
       secondary: '#5c29b1'
-  filter_limit: # Maximum number filter values allowed for anonymous users
+  filter_limit: # Maximum number of filter values allowed for anonymous users
 development:
   <<: *default
 

--- a/test/controllers/materials_controller_test.rb
+++ b/test/controllers/materials_controller_test.rb
@@ -1763,4 +1763,60 @@ class MaterialsControllerTest < ActionController::TestCase
       assert_select '#space-info', count: 0
     end
   end
+
+  test 'displays warning when filter limit reached for anonymous users' do
+    with_settings(solr_enabled: true, filter_limit: 2) do
+      Material.stub(:search_and_filter, MockSearch.new(Material.all)) do
+        get :index, params: { keywords: ['dancing', 'singing'] }
+
+        assert_response :success
+      end
+    end
+
+    assert_select 'div.alert', text: /Filter limit reached/
+    assert_select '.facet-option.filter-limit-reached'
+  end
+
+  test 'does not display filter limit warning for logged-in users' do
+    sign_in(@user)
+
+    with_settings(solr_enabled: true, filter_limit: 2) do
+      Material.stub(:search_and_filter, MockSearch.new(Material.all)) do
+        get :index, params: { keywords: ['dancing', 'singing'] }
+
+        assert_response :success
+      end
+    end
+
+    assert_select 'div.alert', text: /Filter limit reached/, count: 0
+    assert_select '.facet-option.filter-limit-reached', count: 0
+  end
+
+  test 'throws error if filter limit exceeded for anonymous users' do
+    with_settings(solr_enabled: true, filter_limit: 2) do
+      Material.stub(:search_and_filter, MockSearch.new(Material.all)) do
+        get :index, params: { keywords: ['dancing', 'singing', 'acrobatics'] }
+
+        assert_response :bad_request
+      end
+    end
+
+    assert_select '#error-message', text: /Filter limit reached/
+  end
+
+  test 'does not throw error if filter limit exceeded for logged-in users' do
+    sign_in(@user)
+
+    with_settings(solr_enabled: true, filter_limit: 2) do
+      Material.stub(:search_and_filter, MockSearch.new(Material.all)) do
+        get :index, params: { keywords: ['dancing', 'singing', 'acrobatics'] }
+
+        assert_response :success
+      end
+    end
+
+    assert_select '#error-message', count: 0
+    assert_select 'div.alert', text: /Filter limit reached/, count: 0
+    assert_select '.facet-option.filter-limit-reached', count: 0
+  end
 end

--- a/test/controllers/materials_controller_test.rb
+++ b/test/controllers/materials_controller_test.rb
@@ -1819,4 +1819,27 @@ class MaterialsControllerTest < ActionController::TestCase
     assert_select 'div.alert', text: /Filter limit reached/, count: 0
     assert_select '.facet-option.filter-limit-reached', count: 0
   end
+
+  test 'does not throw error if filter limit exceeded for API requests' do
+    with_settings(solr_enabled: true, filter_limit: 2) do
+      Material.stub(:search_and_filter, MockSearch.new(Material.all)) do
+        get :index, params: { keywords: ['dancing', 'singing', 'acrobatics'], format: :json_api }
+
+        assert_response :success
+        assert_not_nil assigns(:materials)
+        assert_valid_json_api_response
+        body = nil
+        assert_nothing_raised do
+          body = JSON.parse(response.body)
+        end
+
+        assert body['data'].any?
+        assert body['meta']['results-count'] > 0
+        assert_includes body['meta']['facets']['keywords'], 'acrobatics'
+        assert body['meta']['available-facets'].keys.any?
+        assert body['meta']['available-facets'].values.any?
+        assert body['links']['self'].include?('acrobatics')
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Summary of changes**

- Adds a configurable filter limit that applies to anonymous users, which limits the number of filter values they can apply (does not apply to API requests).
- Displays a warning message when this limit is hit.
- Returns a 400 error code and does not filter at all if limit is exceeded.

**Motivation and context**

Crawlers were hammering production instances by trying every possibly permutation of filters.

**Screenshots**

<img width="1055" height="325" alt="image" src="https://github.com/user-attachments/assets/5aac90f8-c66a-4f2b-ab92-dcb3f6951e8c" />

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree to license it to the TeSS codebase under the [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
